### PR TITLE
Immutable dynamic object

### DIFF
--- a/DynamicObj.sln
+++ b/DynamicObj.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31515.178
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31521.260
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "DynamicObj", "src\DynamicObj\DynamicObj.fsproj", "{B8BF1554-AAC3-434E-9502-FC83B43F3704}"
 EndProject
@@ -38,6 +38,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{42AA66FC-8
 		docs\index.fsx = docs\index.fsx
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharpTests", "tests\CSharpTests\CSharpTests.csproj", "{D62D0901-DB69-4C64-AC63-FBBBDCF6BC7D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{988D804A-3A42-4E46-B233-B64F5C22524B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -52,9 +56,17 @@ Global
 		{D009964D-9408-4344-B610-B73F54FE2A86}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D009964D-9408-4344-B610-B73F54FE2A86}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D009964D-9408-4344-B610-B73F54FE2A86}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D62D0901-DB69-4C64-AC63-FBBBDCF6BC7D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D62D0901-DB69-4C64-AC63-FBBBDCF6BC7D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D62D0901-DB69-4C64-AC63-FBBBDCF6BC7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D62D0901-DB69-4C64-AC63-FBBBDCF6BC7D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{D009964D-9408-4344-B610-B73F54FE2A86} = {988D804A-3A42-4E46-B233-B64F5C22524B}
+		{D62D0901-DB69-4C64-AC63-FBBBDCF6BC7D} = {988D804A-3A42-4E46-B233-B64F5C22524B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6F5C3597-4524-4A4E-94EC-44857BD0BCEC}

--- a/src/DynamicObj/DynamicObj.fsproj
+++ b/src/DynamicObj/DynamicObj.fsproj
@@ -23,6 +23,7 @@
   
   <ItemGroup>
     <Compile Include="ReflectionUtils.fs" />
+    <Compile Include="ImmutableDynamicObj.fs" />
     <Compile Include="DynamicObj.fs" />
     <Compile Include="DynObj.fs" />
     <None Include="Playground.fsx" />

--- a/src/DynamicObj/DynamicObj.fsproj
+++ b/src/DynamicObj/DynamicObj.fsproj
@@ -26,6 +26,7 @@
     <Compile Include="ImmutableDynamicObj.fs" />
     <Compile Include="DynamicObj.fs" />
     <Compile Include="DynObj.fs" />
+    <Compile Include="Operators.fs" />
     <None Include="Playground.fsx" />
   </ItemGroup>
   

--- a/src/DynamicObj/ImmutableDynamicObj.fs
+++ b/src/DynamicObj/ImmutableDynamicObj.fs
@@ -17,6 +17,16 @@ type ImmutableDynamicObj (map : Map<string, obj>) =
         | Some(value) when value = newValue -> object
         | _ -> ImmutableDynamicObj (Map.add name newValue object.Properties)
 
+    static member (+=) (object, (name, newValue)) = ImmutableDynamicObj.With name newValue object
+
+    member this.TryGetTypedValue<'a> name = 
+        match (this.Properties.TryFind name) with
+        | None -> None
+        | Some o -> 
+            match o with
+            | :? 'a as o -> o |> Some
+            | _ -> None
+
     override this.Equals o =
         match o with
         | :? ImmutableDynamicObj as other -> other.Properties = this.Properties

--- a/src/DynamicObj/ImmutableDynamicObj.fs
+++ b/src/DynamicObj/ImmutableDynamicObj.fs
@@ -65,16 +65,6 @@ type ImmutableDynamicObj internal (map : Map<string, obj>) =
         |> Map.remove name
         |> ImmutableDynamicObj.newIfNeeded object
 
-    /// Returns an instance with:
-    /// 1. this property added if it wasn't present
-    /// 2. this property updated otherwise
-    static member (++) (object, (name, newValue)) = ImmutableDynamicObj.add name newValue object
-
-    /// Returns an instance:
-    /// 1. the same if there was no requested property
-    /// 2. without the requested property if there was
-    static member (--) (object, name) = ImmutableDynamicObj.remove name object
-
     member this.TryGetValue name = 
         match this.Properties.TryGetValue name with
         | true, value ->  Some value

--- a/src/DynamicObj/ImmutableDynamicObj.fs
+++ b/src/DynamicObj/ImmutableDynamicObj.fs
@@ -4,6 +4,9 @@ open DynamicObj
 open System
 open System.Runtime.CompilerServices
 
+[<InternalsVisibleToAttribute("UnitTests")>]
+do()
+
 /// Represents an DynamicObj's counterpart
 /// with immutability enabled only.
 type ImmutableDynamicObj (map : Map<string, obj>) = 
@@ -39,7 +42,7 @@ type ImmutableDynamicObj (map : Map<string, obj>) =
     /// 1. this property added if it wasn't present
     /// 2. this property updated otherwise
     /// Use With from F#. This one is only for non-F# code.
-    static member WithCLSCompliant name newValue (object : 'a when 'a :> ImmutableDynamicObj) =
+    static member internal WithCLSCompliant name newValue (object : 'a when 'a :> ImmutableDynamicObj) =
         object.Properties
         |> Map.add name newValue
         |> ImmutableDynamicObj.NewIfNeededCLSCompliant object
@@ -56,7 +59,7 @@ type ImmutableDynamicObj (map : Map<string, obj>) =
     /// 1. the same if there was no requested property
     /// 2. without the requested property if there was
     /// Use Without from F#. This one is only for non-F# code.
-    static member WithoutCLSCompliant name (object : 'a when 'a :> ImmutableDynamicObj) =
+    static member internal WithoutCLSCompliant name (object : 'a when 'a :> ImmutableDynamicObj) =
         object.Properties
         |> Map.remove name
         |> ImmutableDynamicObj.NewIfNeededCLSCompliant object

--- a/src/DynamicObj/ImmutableDynamicObj.fs
+++ b/src/DynamicObj/ImmutableDynamicObj.fs
@@ -10,8 +10,6 @@ type ImmutableDynamicObj (map : Map<string, obj>) =
     
     let properties = map
     
-    // they're public, but because they're inline,
-    // they won't be visible from other assemblies
     member this.Properties = properties
     
     static member private NewIfNeededCLSCompliant (object : 'a when 'a :> ImmutableDynamicObj) map : 'a =

--- a/src/DynamicObj/ImmutableDynamicObj.fs
+++ b/src/DynamicObj/ImmutableDynamicObj.fs
@@ -9,20 +9,22 @@ do()
 
 /// Represents an DynamicObj's counterpart
 /// with immutability enabled only.
-type ImmutableDynamicObj (map : Map<string, obj>) = 
+type ImmutableDynamicObj internal (map : Map<string, obj>) = 
     
     let mutable properties = map
     
-    member private this.Properties = properties
-    member private this.MutateSetMap newMap =
-        properties <- newMap
+    member private this.Properties 
+        with get () =
+            properties
+        and set value =
+            properties <- value
     
     static member private NewIfNeeded (object : 'a when 'a :> ImmutableDynamicObj) map : 'a =
         if obj.ReferenceEquals(map, object.Properties) then
             object
         else
             let res = new 'a()
-            res.MutateSetMap map
+            res.Properties <- map
             res
 
     /// Empty instance

--- a/src/DynamicObj/ImmutableDynamicObj.fs
+++ b/src/DynamicObj/ImmutableDynamicObj.fs
@@ -8,7 +8,7 @@ open System.Runtime.CompilerServices
 /// with immutability enabled only.
 type ImmutableDynamicObj (map : Map<string, obj>) = 
     
-    let mutable properties = map
+    let properties = map
     
     // they're public, but because they're inline,
     // they won't be visible from other assemblies

--- a/src/DynamicObj/ImmutableDynamicObj.fs
+++ b/src/DynamicObj/ImmutableDynamicObj.fs
@@ -8,8 +8,10 @@ type ImmutableDynamicObj (map : Map<string, obj>) =
     
     let mutable properties = map
     
-    member private this.Properties = properties
-    member private this.ForceReplaceMap map =
+    // they're public, but because they're inline,
+    // they won't be visible from other assemblies
+    member inline this.Properties = properties
+    member inline this.ForceReplaceMap map =
         properties <- map
 
     static member inline private NewIfNeeded (a : ^ImmutableDynamicObj) map : ^ImmutableDynamicObj =
@@ -49,7 +51,7 @@ type ImmutableDynamicObj (map : Map<string, obj>) =
     /// Returns an instance with:
     /// 1. this property added if it wasn't present
     /// 2. this property updated otherwise
-    static member inline (+=) (object, (name, newValue)) = ImmutableDynamicObj.With name newValue object
+    static member  (+=) (object, (name, newValue)) = ImmutableDynamicObj.With name newValue object
 
     /// Returns an instance:
     /// 1. the same if there was no requested property

--- a/src/DynamicObj/ImmutableDynamicObj.fs
+++ b/src/DynamicObj/ImmutableDynamicObj.fs
@@ -27,7 +27,7 @@ type ImmutableDynamicObj internal (map : Map<string, obj>) =
             let fieldValue = fi.GetValue sourceObject
             fi.SetValue(destinationObject, fieldValue)
 
-    static member private NewIfNeeded (object : 'a when 'a :> ImmutableDynamicObj) map : 'a =
+    static member private newIfNeeded (object : 'a when 'a :> ImmutableDynamicObj) map : 'a =
         if obj.ReferenceEquals(map, object.Properties) then
             object
         else
@@ -52,28 +52,28 @@ type ImmutableDynamicObj internal (map : Map<string, obj>) =
     /// Returns an instance with:
     /// 1. this property added if it wasn't present
     /// 2. this property updated otherwise
-    static member With name newValue (object : #ImmutableDynamicObj) =
+    static member add name newValue (object : #ImmutableDynamicObj) =
         object.Properties
         |> Map.add name newValue
-        |> ImmutableDynamicObj.NewIfNeeded object
+        |> ImmutableDynamicObj.newIfNeeded object
 
     /// Returns an instance:
     /// 1. the same if there was no requested property
     /// 2. without the requested property if there was
-    static member Without name (object : #ImmutableDynamicObj) =
+    static member remove name (object : #ImmutableDynamicObj) =
         object.Properties
         |> Map.remove name
-        |> ImmutableDynamicObj.NewIfNeeded object
+        |> ImmutableDynamicObj.newIfNeeded object
 
     /// Returns an instance with:
     /// 1. this property added if it wasn't present
     /// 2. this property updated otherwise
-    static member (++) (object, (name, newValue)) = ImmutableDynamicObj.With name newValue object
+    static member (++) (object, (name, newValue)) = ImmutableDynamicObj.add name newValue object
 
     /// Returns an instance:
     /// 1. the same if there was no requested property
     /// 2. without the requested property if there was
-    static member (--) (object, name) = ImmutableDynamicObj.Without name object
+    static member (--) (object, name) = ImmutableDynamicObj.remove name object
 
     member this.TryGetValue name = 
         match this.Properties.TryGetValue name with
@@ -103,13 +103,13 @@ type ImmutableDynamicObjExtensions =
     /// 2. this property updated otherwise
     /// use this one only from C#
     [<Extension>]
-    static member With (this, name, newValue) =
-        ImmutableDynamicObj.With name newValue this
+    static member AddItem (this, name, newValue) =
+        ImmutableDynamicObj.add name newValue this
 
     /// Returns an instance:
     /// 1. the same if there was no requested property
     /// 2. without the requested property if there was
     /// use this one only from C#
     [<Extension>]
-    static member Without (this, name) =
-        ImmutableDynamicObj.Without name this
+    static member RemoveItem (this, name) =
+        ImmutableDynamicObj.remove name this

--- a/src/DynamicObj/ImmutableDynamicObj.fs
+++ b/src/DynamicObj/ImmutableDynamicObj.fs
@@ -1,0 +1,25 @@
+﻿module ImmutableDynamicObj
+
+type ImmutableDynamicObj (map : Map<string, obj>) = 
+    
+    let properties = map
+    
+    member private this.Properties = properties
+
+    new () = ImmutableDynamicObj Map.empty
+
+    member this.Item
+        with get(index) =
+            this.Properties.[index]
+
+    static member With name newValue (object : ImmutableDynamicObj) =
+        match Map.tryFind name object.Properties with
+        | Some(value) when value = newValue -> object
+        | _ -> ImmutableDynamicObj (Map.add name newValue object.Properties)
+
+    override this.Equals o =
+        match o with
+        | :? ImmutableDynamicObj as other -> other.Properties = this.Properties
+        | _ -> false
+
+    override this.GetHashCode () = ~~~map.GetHashCode()

--- a/src/DynamicObj/ImmutableDynamicObj.fs
+++ b/src/DynamicObj/ImmutableDynamicObj.fs
@@ -65,6 +65,25 @@ type ImmutableDynamicObj internal (map : Map<string, obj>) =
         |> Map.remove name
         |> ImmutableDynamicObj.newIfNeeded object
 
+
+    
+        
+
+    /// Acts as add if the value is Some,
+    /// returns the same object otherwise
+    static member addOpt name newValue object =
+        match newValue with
+        | Some(value) -> object |> ImmutableDynamicObj.add name value
+        | None -> object
+
+
+    /// Acts as addOpt but maps the valid value 
+    /// through the last argument
+    static member addOptBy name newValue f object =
+        match newValue with
+        | Some(value) -> object |> ImmutableDynamicObj.add name (f value)
+        | None -> object
+
     member this.TryGetValue name = 
         match this.Properties.TryGetValue name with
         | true, value ->  Some value

--- a/src/DynamicObj/Operators.fs
+++ b/src/DynamicObj/Operators.fs
@@ -17,13 +17,11 @@ let (--) object name = ImmutableDynamicObj.remove name object
 /// Acts as (++) if the value is Some,
 /// returns the same object otherwise
 let (++?) object (name, newValue) =
-    match newValue with
-    | Some(value) -> object ++ (name, value)
-    | None -> object
+    object
+    |> ImmutableDynamicObj.addOpt name newValue
 
 /// Acts as (++?) but maps the valid value 
 /// through the last argument
 let (++??) object (name, newValue, f) =
-    match newValue with
-    | Some(value) -> object ++ (name, f value)
-    | None -> object
+    object
+    |> ImmutableDynamicObj.addOptBy name newValue f

--- a/src/DynamicObj/Operators.fs
+++ b/src/DynamicObj/Operators.fs
@@ -1,0 +1,29 @@
+﻿module DynamicObj.Operators
+
+
+
+/// Returns an instance with:
+/// 1. this property added if it wasn't present
+/// 2. this property updated otherwise
+let (++) object (name, newValue) = ImmutableDynamicObj.add name newValue object
+
+
+/// Returns an instance:
+/// 1. the same if there was no requested property
+/// 2. without the requested property if there was
+let (--) object name = ImmutableDynamicObj.remove name object
+
+
+/// Acts as (++) if the value is Some,
+/// returns the same object otherwise
+let (++?) object (name, newValue) =
+    match newValue with
+    | Some(value) -> object ++ (name, value)
+    | None -> object
+
+/// Acts as (++?) but maps the valid value 
+/// through the last argument
+let (++??) object (name, newValue, f) =
+    match newValue with
+    | Some(value) -> object ++ (name, f value)
+    | None -> object

--- a/tests/CSharpTests/CSharpTests.csproj
+++ b/tests/CSharpTests/CSharpTests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\DynamicObj\DynamicObj.fsproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/CSharpTests/InteropWorks.cs
+++ b/tests/CSharpTests/InteropWorks.cs
@@ -1,0 +1,25 @@
+using System;
+using Xunit;
+using DynamicObj;
+
+namespace CSharpTests
+{
+    public class InteropWorks
+    {
+        [Fact]
+        public void Test1()
+        {
+            var obj1 =
+                new ImmutableDynamicObj()
+                .With("aa", 4)
+                .With("bb", 10)
+                .Without("aa")
+                ;
+            var obj2 = 
+                new ImmutableDynamicObj()
+                .With("bb", 10)
+                ;
+            Assert.Equal(obj1, obj2);
+        }
+    }
+}

--- a/tests/CSharpTests/InteropWorks.cs
+++ b/tests/CSharpTests/InteropWorks.cs
@@ -39,5 +39,20 @@ namespace CSharpTests
             Assert.IsType<MyDynamicObject>(obj1);
             Assert.Equal(5, obj1["aaa"]);
         }
+
+        public class MyDynamicObjectWithField : ImmutableDynamicObj
+        {
+            public int Aaa { get; init; }
+        }
+
+        [Fact]
+        public void TestFieldsPreservedForInheritor()
+        {
+            var obj1 =
+                new MyDynamicObjectWithField() { Aaa = 100500 }
+                .With("aaa", 5)
+                .Without("aaa");
+            Assert.Equal(100500, obj1.Aaa);
+        }
     }
 }

--- a/tests/CSharpTests/InteropWorks.cs
+++ b/tests/CSharpTests/InteropWorks.cs
@@ -14,13 +14,13 @@ namespace CSharpTests
         {
             var obj1 =
                 new ImmutableDynamicObj()
-                .With("aa", 4)
-                .With("bb", 10)
-                .Without("aa")
+                .AddItem("aa", 4)
+                .AddItem("bb", 10)
+                .RemoveItem("aa")
                 ;
             var obj2 = 
                 new ImmutableDynamicObj()
-                .With("bb", 10)
+                .AddItem("bb", 10)
                 ;
             Assert.Equal(obj1, obj2);
         }
@@ -35,7 +35,7 @@ namespace CSharpTests
         {
             var obj1 =
                 new MyDynamicObject()
-                .With("aaa", 5);
+                .AddItem("aaa", 5);
             Assert.IsType<MyDynamicObject>(obj1);
             Assert.Equal(5, obj1["aaa"]);
         }
@@ -50,8 +50,8 @@ namespace CSharpTests
         {
             var obj1 =
                 new MyDynamicObjectWithField() { Aaa = 100500 }
-                .With("aaa", 5)
-                .Without("aaa");
+                .AddItem("aaa", 5)
+                .RemoveItem("aaa");
             Assert.Equal(100500, obj1.Aaa);
         }
     }

--- a/tests/CSharpTests/InteropWorks.cs
+++ b/tests/CSharpTests/InteropWorks.cs
@@ -1,6 +1,9 @@
 using System;
 using Xunit;
 using DynamicObj;
+using Microsoft.FSharp.Collections;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace CSharpTests
 {
@@ -20,6 +23,22 @@ namespace CSharpTests
                 .With("bb", 10)
                 ;
             Assert.Equal(obj1, obj2);
+        }
+
+        public class MyDynamicObject : ImmutableDynamicObj
+        {
+            public MyDynamicObject(FSharpMap<string, object> map) : base(map) { }
+            public MyDynamicObject() : base(new(Enumerable.Empty<Tuple<string, object>>())) { }
+        }
+
+        [Fact]
+        public void Test2()
+        {
+            var obj1 =
+                new MyDynamicObject()
+                .With("aaa", 5);
+            Assert.IsType<MyDynamicObject>(obj1);
+            Assert.Equal(5, obj1["aaa"]);
         }
     }
 }

--- a/tests/CSharpTests/InteropWorks.cs
+++ b/tests/CSharpTests/InteropWorks.cs
@@ -27,8 +27,7 @@ namespace CSharpTests
 
         public class MyDynamicObject : ImmutableDynamicObj
         {
-            public MyDynamicObject(FSharpMap<string, object> map) : base(map) { }
-            public MyDynamicObject() : base(new(Enumerable.Empty<Tuple<string, object>>())) { }
+            
         }
 
         [Fact]

--- a/tests/UnitTests/ImmTests.fs
+++ b/tests/UnitTests/ImmTests.fs
@@ -1,7 +1,7 @@
-﻿module ImmTests
+﻿module Tests.ImmTests
 
 open Xunit
-open ImmutableDynamicObj
+open DynamicObj
 
 [<Fact>]
 let ``No mutation test 1`` () =
@@ -29,18 +29,18 @@ let ``No mutation test 1`` () =
 let ``No mutation test 1 with operators`` () =
     let obj1 =
         ImmutableDynamicObj ()
-        += ("aa", 5)
+        ++ ("aa", 5)
     let obj2 = 
         ImmutableDynamicObj ()
-        += ("bb", 10)
+        ++ ("bb", 10)
 
     let objBase = ImmutableDynamicObj ()
     let objA = 
         objBase
-        += ("aa", 5)
+        ++ ("aa", 5)
     let objB = 
         objBase
-        += ("bb", 10)
+        ++ ("bb", 10)
     Assert.Equal(obj1, objA)
     Assert.Equal(obj2, objB)
 
@@ -51,13 +51,13 @@ let ``No mutation test 1 with operators`` () =
 let ``Deterministic 1`` () =
     let obj1 =
         ImmutableDynamicObj ()
-        += ("aaa", 5)
-        += ("bbb", "ccc")
+        ++ ("aaa", 5)
+        ++ ("bbb", "ccc")
 
     let obj2 =
         ImmutableDynamicObj ()
-        += ("aaa", 5)
-        += ("bbb", "ccc")
+        ++ ("aaa", 5)
+        ++ ("bbb", "ccc")
 
     Assert.Equal(obj1, obj2)
 
@@ -65,13 +65,13 @@ let ``Deterministic 1`` () =
 let ``Determinstic 2`` () =
     let obj1 =
         ImmutableDynamicObj ()
-        += ("aaa", 5)
-        += ("bbb", "ccc")
-        -= "aaa"
+        ++ ("aaa", 5)
+        ++ ("bbb", "ccc")
+        -- "aaa"
 
     let obj2 =
         ImmutableDynamicObj ()
-        += ("bbb", "ccc")
+        ++ ("bbb", "ccc")
 
     Assert.Equal(obj1, obj2)
 
@@ -79,12 +79,12 @@ let ``Determinstic 2`` () =
 let ``Determinstic 3`` () =
     let obj1 =
         ImmutableDynamicObj ()
-        -= "aaa"
-        += ("bbb", "ccc")
+        -- "aaa"
+        ++ ("bbb", "ccc")
 
     let obj2 =
         ImmutableDynamicObj ()
-        += ("bbb", "ccc")
+        ++ ("bbb", "ccc")
 
     Assert.Equal(obj1, obj2)
 
@@ -95,25 +95,74 @@ let ``Non-equal test 1`` () =
 
     let obj2 = 
         ImmutableDynamicObj ()
-        += ("quack", 5)
+        ++ ("quack", 5)
 
     Assert.NotEqual(obj1, obj2)
 
-type Quack () =
-    inherit ImmutableDynamicObj ()
+type Quack (map) =
+    inherit ImmutableDynamicObj (map)
+
+    new() = Quack (Map.empty)
+
 
 [<Fact>]
-let ``Type preserved 1`` () =
+let ``Type preserved F# 1`` () =
     let obj1 =
         Quack ()
-        += ("aaa", 5)
+        ++ ("aaa", 5)
     Assert.IsType<Quack>(obj1)
 
 [<Fact>]
-let ``Type preserved 2`` () =
+let ``Type preserved F# 2`` () =
     let obj1 =
         Quack ()
-        += ("aaa", 5)
-        -= "aaa"
-        += ("bbb", 5)
+        ++ ("aaa", 5)
+        -- "aaa"
+        ++ ("bbb", 5)
     Assert.IsType<Quack>(obj1)
+
+[<Fact>]
+let ``Type preserved CLS Compliant 1`` () =
+    let obj1 =
+        Quack ()
+        |> Quack.WithCLSCompliant "aaa" 5
+    Assert.IsType<Quack>(obj1)
+
+[<Fact>]
+let ``Type preserved CLS Compliant 2`` () =
+    let obj1 =
+        Quack ()
+        |> Quack.WithCLSCompliant "aaa" 5
+        |> Quack.WithoutCLSCompliant "aaa"
+        |> Quack.WithCLSCompliant "bbb" 5
+    Assert.IsType<Quack>(obj1)
+
+[<Fact>]
+let ``Type preserved CLS Compliant and F# the same thing 1`` () =
+    let obj1 =
+        Quack ()
+        |> Quack.WithCLSCompliant "aaa" 5
+        |> Quack.WithCLSCompliant "bbb" 5
+
+    let obj2 =
+        Quack ()
+        ++ ("aaa", 5)
+        ++ ("bbb", 5)
+
+    Assert.Equal(obj1, obj2)
+
+[<Fact>]
+let ``Type preserved CLS Compliant and F# the same thing 2`` () =
+    let obj1 =
+        Quack ()
+        |> Quack.WithCLSCompliant "aaa" 5
+        |> Quack.WithCLSCompliant "bbb" 5
+        |> Quack.WithoutCLSCompliant "aaa"
+
+    let obj2 =
+        Quack ()
+        ++ ("aaa", 5)
+        ++ ("bbb", 5)
+        -- "aaa"
+
+    Assert.Equal(obj1, obj2)

--- a/tests/UnitTests/ImmTests.fs
+++ b/tests/UnitTests/ImmTests.fs
@@ -4,6 +4,33 @@ open Xunit
 open DynamicObj
 
 [<Fact>]
+let ``Value test 1`` () =
+    let obj1 = 
+        ImmutableDynamicObj.empty
+        ++ ("aaa", 5)
+    Assert.Equal(obj1.["aaa"], 5);
+
+[<Fact>]
+let ``Value test 2`` () =
+    let obj1 = 
+        ImmutableDynamicObj.empty
+        ++ ("aaa", 5)
+        ++ ("bbb", "quack")
+    Assert.Equal(obj1.["aaa"], 5);
+    Assert.Equal(obj1.["bbb"], "quack");
+   
+[<Fact>]
+let ``Value test 3`` () =
+    let obj1 =
+        ImmutableDynamicObj.empty
+        ++ ("aaa", 5)
+        -- "aaa"
+    match obj1.TryGetValue "aaa" with
+    | Some(value) -> Assert.False(true, "Should return None")
+    | _ -> ()
+
+
+[<Fact>]
 let ``No mutation test 1`` () =
     let obj1 =
         ImmutableDynamicObj ()
@@ -120,49 +147,3 @@ let ``Type preserved F# 2`` () =
         -- "aaa"
         ++ ("bbb", 5)
     Assert.IsType<Quack>(obj1)
-
-[<Fact>]
-let ``Type preserved CLS Compliant 1`` () =
-    let obj1 =
-        Quack ()
-        |> Quack.WithCLSCompliant "aaa" 5
-    Assert.IsType<Quack>(obj1)
-
-[<Fact>]
-let ``Type preserved CLS Compliant 2`` () =
-    let obj1 =
-        Quack ()
-        |> Quack.WithCLSCompliant "aaa" 5
-        |> Quack.WithoutCLSCompliant "aaa"
-        |> Quack.WithCLSCompliant "bbb" 5
-    Assert.IsType<Quack>(obj1)
-
-[<Fact>]
-let ``Type preserved CLS Compliant and F# the same thing 1`` () =
-    let obj1 =
-        Quack ()
-        |> Quack.WithCLSCompliant "aaa" 5
-        |> Quack.WithCLSCompliant "bbb" 5
-
-    let obj2 =
-        Quack ()
-        ++ ("aaa", 5)
-        ++ ("bbb", 5)
-
-    Assert.Equal(obj1, obj2)
-
-[<Fact>]
-let ``Type preserved CLS Compliant and F# the same thing 2`` () =
-    let obj1 =
-        Quack ()
-        |> Quack.WithCLSCompliant "aaa" 5
-        |> Quack.WithCLSCompliant "bbb" 5
-        |> Quack.WithoutCLSCompliant "aaa"
-
-    let obj2 =
-        Quack ()
-        ++ ("aaa", 5)
-        ++ ("bbb", 5)
-        -- "aaa"
-
-    Assert.Equal(obj1, obj2)

--- a/tests/UnitTests/ImmTests.fs
+++ b/tests/UnitTests/ImmTests.fs
@@ -21,5 +21,28 @@ let ``No mutation test 1`` () =
         |> ImmutableDynamicObj.With "bb" 10
     Assert.Equal(obj1, objA)
     Assert.Equal(obj2, objB)
+
+    Assert.True((obj1 = objA))
+    Assert.True((obj2 = objB))
+
+[<Fact>]
+let ``No mutation test 1 with operators`` () =
+    let obj1 =
+        ImmutableDynamicObj ()
+        += ("aa", 5)
+    let obj2 = 
+        ImmutableDynamicObj ()
+        += ("bb", 10)
+
+    let objBase = ImmutableDynamicObj ()
+    let objA = 
+        objBase
+        += ("aa", 5)
+    let objB = 
+        objBase
+        += ("bb", 10)
+    Assert.Equal(obj1, objA)
+    Assert.Equal(obj2, objB)
+
     Assert.True((obj1 = objA))
     Assert.True((obj2 = objB))

--- a/tests/UnitTests/ImmTests.fs
+++ b/tests/UnitTests/ImmTests.fs
@@ -46,3 +46,55 @@ let ``No mutation test 1 with operators`` () =
 
     Assert.True((obj1 = objA))
     Assert.True((obj2 = objB))
+
+[<Fact>]
+let ``Deterministic 1`` () =
+    let obj1 =
+        ImmutableDynamicObj ()
+        += ("aaa", 5)
+        += ("bbb", "ccc")
+
+    let obj2 =
+        ImmutableDynamicObj ()
+        += ("aaa", 5)
+        += ("bbb", "ccc")
+
+    Assert.Equal(obj1, obj2)
+
+[<Fact>]
+let ``Determinstic 2`` () =
+    let obj1 =
+        ImmutableDynamicObj ()
+        += ("aaa", 5)
+        += ("bbb", "ccc")
+        -= "aaa"
+
+    let obj2 =
+        ImmutableDynamicObj ()
+        += ("bbb", "ccc")
+
+    Assert.Equal(obj1, obj2)
+
+[<Fact>]
+let ``Determinstic 3`` () =
+    let obj1 =
+        ImmutableDynamicObj ()
+        -= "aaa"
+        += ("bbb", "ccc")
+
+    let obj2 =
+        ImmutableDynamicObj ()
+        += ("bbb", "ccc")
+
+    Assert.Equal(obj1, obj2)
+
+[<Fact>]
+let ``Non-equal test 1`` () =
+    let obj1 =
+        ImmutableDynamicObj ()
+
+    let obj2 = 
+        ImmutableDynamicObj ()
+        += ("quack", 5)
+
+    Assert.NotEqual(obj1, obj2)

--- a/tests/UnitTests/ImmTests.fs
+++ b/tests/UnitTests/ImmTests.fs
@@ -147,3 +147,37 @@ let ``Type preserved F# 2`` () =
         -- "aaa"
         ++ ("bbb", 5)
     Assert.IsType<Quack>(obj1)
+
+
+type QuackWithField (map, field) =
+    inherit ImmutableDynamicObj (map)
+    let field = field
+    member _.Field = field
+
+    new() = QuackWithField (Map.empty, 5)
+
+
+[<Fact>]
+let ``Fields of the closest inheritor preserved 1`` () =
+    let obj1 =
+        QuackWithField (Map.empty, 100)
+        ++ ("aaa", 5)
+        -- "bbb"
+    Assert.Equal(100, obj1.Field);
+
+type FarQuackWithField (someOtherField) =
+    inherit QuackWithField (Map.empty, 55)
+    let otherField = someOtherField
+    member _.OtherField = otherField
+
+    new() = FarQuackWithField(3)
+
+[<Fact>]
+let ``Fields of a far inheritor preserved 1`` () =
+    let obj1 =
+        FarQuackWithField (1234)
+        ++ ("aaa", 5)
+        -- "bbb"
+    Assert.Equal(1234, obj1.OtherField);
+    Assert.Equal(55, obj1.Field);
+    Assert.Equal(5 :> obj, obj1.["aaa"]);

--- a/tests/UnitTests/ImmTests.fs
+++ b/tests/UnitTests/ImmTests.fs
@@ -1,0 +1,25 @@
+﻿module ImmTests
+
+open Xunit
+open ImmutableDynamicObj
+
+[<Fact>]
+let ``No mutation test 1`` () =
+    let obj1 =
+        ImmutableDynamicObj ()
+        |> ImmutableDynamicObj.With "aa" 5
+    let obj2 = 
+        ImmutableDynamicObj ()
+        |> ImmutableDynamicObj.With "bb" 10
+
+    let objBase = ImmutableDynamicObj ()
+    let objA = 
+        objBase
+        |> ImmutableDynamicObj.With "aa" 5
+    let objB = 
+        objBase
+        |> ImmutableDynamicObj.With "bb" 10
+    Assert.Equal(obj1, objA)
+    Assert.Equal(obj2, objB)
+    Assert.True((obj1 = objA))
+    Assert.True((obj2 = objB))

--- a/tests/UnitTests/ImmTests.fs
+++ b/tests/UnitTests/ImmTests.fs
@@ -2,6 +2,7 @@
 
 open Xunit
 open DynamicObj
+open DynamicObj.Operators
 
 [<Fact>]
 let ``Value test 1`` () =

--- a/tests/UnitTests/ImmTests.fs
+++ b/tests/UnitTests/ImmTests.fs
@@ -34,18 +34,18 @@ let ``Value test 3`` () =
 let ``No mutation test 1`` () =
     let obj1 =
         ImmutableDynamicObj ()
-        |> ImmutableDynamicObj.With "aa" 5
+        |> ImmutableDynamicObj.add "aa" 5
     let obj2 = 
         ImmutableDynamicObj ()
-        |> ImmutableDynamicObj.With "bb" 10
+        |> ImmutableDynamicObj.add "bb" 10
 
     let objBase = ImmutableDynamicObj ()
     let objA = 
         objBase
-        |> ImmutableDynamicObj.With "aa" 5
+        |> ImmutableDynamicObj.add "aa" 5
     let objB = 
         objBase
-        |> ImmutableDynamicObj.With "bb" 10
+        |> ImmutableDynamicObj.add "bb" 10
     Assert.Equal(obj1, objA)
     Assert.Equal(obj2, objB)
 

--- a/tests/UnitTests/ImmTests.fs
+++ b/tests/UnitTests/ImmTests.fs
@@ -98,3 +98,22 @@ let ``Non-equal test 1`` () =
         += ("quack", 5)
 
     Assert.NotEqual(obj1, obj2)
+
+type Quack () =
+    inherit ImmutableDynamicObj ()
+
+[<Fact>]
+let ``Type preserved 1`` () =
+    let obj1 =
+        Quack ()
+        += ("aaa", 5)
+    Assert.IsType<Quack>(obj1)
+
+[<Fact>]
+let ``Type preserved 2`` () =
+    let obj1 =
+        Quack ()
+        += ("aaa", 5)
+        -= "aaa"
+        += ("bbb", 5)
+    Assert.IsType<Quack>(obj1)

--- a/tests/UnitTests/OperatorsTests.fs
+++ b/tests/UnitTests/OperatorsTests.fs
@@ -1,0 +1,35 @@
+﻿module Tests.OperatorsTests
+
+open Xunit
+open DynamicObj
+open DynamicObj.Operators
+
+[<Fact>]
+let ``Test ++? 1`` () =
+    let obj1 = 
+        ImmutableDynamicObj.empty
+        ++? ("aaa", Some(5))
+    let expected =
+        ImmutableDynamicObj.empty
+        ++ ("aaa", 5)
+    Assert.Equal(expected, obj1)
+
+[<Fact>]
+let ``Test ++? 2`` () =
+    let obj1 = 
+        ImmutableDynamicObj.empty
+        ++? ("aaa", None)
+    let expected =
+        ImmutableDynamicObj.empty
+    Assert.Equal(expected, obj1)
+
+[<Fact>]
+let ``Test ++?? 1`` () =
+    let obj1 = 
+        ImmutableDynamicObj.empty
+        ++?? ("aaa", Some(5), fun c -> c * 10)
+    let expected =
+        ImmutableDynamicObj.empty
+        ++ ("aaa", 50)
+    Assert.Equal(expected, obj1)
+

--- a/tests/UnitTests/UnitTests.fsproj
+++ b/tests/UnitTests/UnitTests.fsproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="ImmTests.fs" />
     <Compile Include="Tests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>

--- a/tests/UnitTests/UnitTests.fsproj
+++ b/tests/UnitTests/UnitTests.fsproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <Compile Include="ImmTests.fs" />
     <Compile Include="Tests.fs" />
+    <Compile Include="OperatorsTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 


### PR DESCRIPTION
Usage:

## F#

#### Simple
```fs
let obj1 =
    ImmutableDynamicObj ()
    ++ ("aaa", 5)
    ++ ("bbb", "ccc")
    -- "aaa"
```
(`obj1` is of type `ImmutableDynamicObj`)

#### With inheritance
```fs
type Quack (map) =
    inherit ImmutableDynamicObj (map)

    new() = Quack (Map.empty)
```
...
```fs
let obj1 =
    Quack ()
    ++ ("aaa", 5)
    -- "aaa"
    ++ ("bbb", 5)
```
(`obj1` is of type `Quack`)

## C#

#### Simple
```cs
var obj1 =
    new ImmutableDynamicObj()
    .With("aa", 4)
    .With("bb", 10)
    .Without("aa")
    ;
```
(`obj1` is of type `ImmutableDynamicObj`)

#### With inheritance
```cs
public class MyDynamicObject : ImmutableDynamicObj
{
    public MyDynamicObject(FSharpMap<string, object> map) : base(map) { }
    public MyDynamicObject() : base(new(Enumerable.Empty<Tuple<string, object>>())) { }
}
```
...
```cs
var obj1 =
    new MyDynamicObject()
    .With("aaa", 5);
```
(`obj1` is of type `MyDynamicObject`)