### PR TITLE
Fix format loop in DynObj.print function

### DIFF
--- a/src/DynamicObj/DynObj.fs
+++ b/src/DynamicObj/DynObj.fs
@@ -102,7 +102,7 @@ module DynObj =
                     let innerPrint = (loop item (identationLevel + 1) innerMembers [])
                     loop object identationLevel rest ($"{ident}?{m}:{System.Environment.NewLine}{innerPrint}" :: acc)
                 | _ -> 
-                    loop d identationLevel rest ($"{ident}?{m}: {item}"::acc)
+                    loop object identationLevel rest ($"{ident}?{m}: {item}"::acc)
     
         loop d 0 members []
 

--- a/tests/UnitTests/Tests.fs
+++ b/tests/UnitTests/Tests.fs
@@ -191,3 +191,21 @@ let ``combine nested DOs``() =
         )
 
     Assert.Equal(expected, combined)
+
+[<Fact>]
+let ``test print for issue 14``() = 
+    // https://github.com/CSBiology/DynamicObj/issues/14
+    let outer = DynamicObj()
+    let inner = DynamicObj()
+    inner.SetValue("Level", "Information")
+    inner.SetValue("MessageTemplate","{Method} Request at {Path}")
+    outer.SetValue("serilog", inner)
+
+    let print =
+        try 
+            outer |> DynObj.print
+            true
+        with
+            | e -> false
+
+    Assert.True(print)


### PR DESCRIPTION
- Fix bug according to Issue #14 .
- Add a simple unit test for it.