### PR TITLE
Add typed property retrieval function

### DIFF
--- a/DynamicObj.sln
+++ b/DynamicObj.sln
@@ -20,6 +20,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".proj", ".proj", "{C3CF2F15-81C7-4C11-889E-5FCA2C8A981D}"
 	ProjectSection(SolutionItems) = preProject
 		.gitignore = .gitignore
+		build.cmd = build.cmd
+		build.sh = build.sh
 		.config\dotnet-tools.json = .config\dotnet-tools.json
 		global.json = global.json
 		key.snk = key.snk

--- a/build.cmd
+++ b/build.cmd
@@ -1,4 +1,6 @@
 @echo off
 cls
 
+set PYTHONIOENCODING=utf-8
+
 dotnet run --project ./build/build.fsproj %*

--- a/src/DynamicObj/DynObj.fs
+++ b/src/DynamicObj/DynObj.fs
@@ -63,6 +63,15 @@ module DynObj =
             | _ -> first.SetValue(kv.Key,kv.Value)
         first
 
+    
+    let inline tryGetTypedValue<'a> (name) (dynObj : DynamicObj) =
+        match (dynObj.TryGetValue name) with
+        | None -> None
+        | Some o -> 
+            match o with
+            | :? 'a as o -> o |> Some
+            | _ -> None
+
     let setValue (dyn:DynamicObj) propName o =
         dyn.SetValue(propName,o)
 

--- a/src/DynamicObj/DynamicObj.fs
+++ b/src/DynamicObj/DynamicObj.fs
@@ -27,20 +27,19 @@ type DynamicObj() =
     member this.GetValue (name) =
         this.TryGetValue(name).Value
 
+    #if !FABLE_COMPILER
     /// Gets typed property value if type matches, otherwise None.
     ///
     /// WARNING: This Method is not supported in Fable transpiled code. Use static method tryGetTypedValue instead.
     member this.TryGetTypedValue<'a> name = 
-        #if !FABLE_COMPILER
+        
         match (this.TryGetValue name) with
         | None -> None
         | Some o ->      
             match o with
             | :? 'a as o -> o |> Some
             | _ -> None
-        #else
-        failwith "Method TryGetTypedValue is not supported in Fable transpiled code. Use static method tryGetTypedValue instead."
-        #endif    
+    #endif    
 
     member this.TryGetStaticPropertyInfo name : PropertyHelper option  = 
         ReflectionUtils.tryGetStaticPropertyInfo this name

--- a/src/DynamicObj/DynamicObj.fs
+++ b/src/DynamicObj/DynamicObj.fs
@@ -27,15 +27,20 @@ type DynamicObj() =
     member this.GetValue (name) =
         this.TryGetValue(name).Value
 
-    /// Gets property value
+    /// Gets typed property value if type matches, otherwise None.
+    ///
+    /// WARNING: This Method is not supported in Fable transpiled code. Use static method tryGetTypedValue instead.
     member this.TryGetTypedValue<'a> name = 
+        #if !FABLE_COMPILER
         match (this.TryGetValue name) with
         | None -> None
-        | Some o -> 
+        | Some o ->      
             match o with
-            | :? 'a -> o :?> 'a |> Some
+            | :? 'a as o -> o |> Some
             | _ -> None
-
+        #else
+        failwith "Method TryGetTypedValue is not supported in Fable transpiled code. Use static method tryGetTypedValue instead."
+        #endif    
 
     member this.TryGetStaticPropertyInfo name : PropertyHelper option  = 
         ReflectionUtils.tryGetStaticPropertyInfo this name

--- a/tests/DynamicObject.Tests/DynamicObj.fs
+++ b/tests/DynamicObject.Tests/DynamicObj.fs
@@ -4,6 +4,67 @@ open System
 open Fable.Pyxpecto
 open DynamicObj
 
+let tests_tryGetTypedValue = testList "TryGetTypedValue" [
+    
+    testCase "typeof" <| fun _ -> 
+        let a = typeof<int>
+        Expect.equal a.Name "Int32" "Type should be Int32"
+
+    testCase "NonExisting" <| fun _ -> 
+        let a = DynamicObj()
+        let b = DynObj.tryGetTypedValue<int> "a" a
+        Expect.isNone b "Value should not exist"
+
+    testCase "Correct Int" <| fun _ -> 
+        let a = DynamicObj()
+        a.SetValue("a", 1)
+        let b = DynObj.tryGetTypedValue<int> "a" a
+        Expect.equal b (Some 1) "Value should be 1"
+
+    testCase "Incorrect Int" <| fun _ ->
+        let a = DynamicObj()
+        a.SetValue("a", "1")
+        let b = DynObj.tryGetTypedValue<int> "a" a
+        Expect.isNone b "Value should not be an int"
+
+    testCase "Correct String" <| fun _ ->
+        let a = DynamicObj()
+        a.SetValue("a", "1")
+        let b = DynObj.tryGetTypedValue<string> "a" a
+        Expect.equal b (Some "1") "Value should be '1'"
+
+    testCase "Incorrect String" <| fun _ ->
+        let a = DynamicObj()
+        a.SetValue("a", 1)
+        let b = DynObj.tryGetTypedValue<string> "a" a
+        Expect.isNone b "Value should not be a string"
+
+    testCase "Correct List" <| fun _ ->
+        let a = DynamicObj()
+        a.SetValue("a", [1; 2; 3])
+        let b = DynObj.tryGetTypedValue<int list> "a" a
+        Expect.equal b (Some [1; 2; 3]) "Value should be [1; 2; 3]"
+
+    ptestCase "Incorrect List" <| fun _ ->
+        let a = DynamicObj()
+        a.SetValue("a", [1; 2; 3])
+        let b = DynObj.tryGetTypedValue<string list> "a" a
+        Expect.isNone b "Value should not be a string list"
+
+    testCase "Correct DynamicObj" <| fun _ ->
+        let a = DynamicObj()
+        let b = DynamicObj()
+        a.SetValue("a", b)
+        let c = DynObj.tryGetTypedValue<DynamicObj> "a" a
+        Expect.equal c (Some b) "Value should be a DynamicObj"
+
+    testCase "Incorrect DynamicObj" <| fun _ ->
+        let a = DynamicObj()
+        a.SetValue("a", 1)
+        let b = DynObj.tryGetTypedValue<DynamicObj> "a" a
+        Expect.isNone b "Value should not be a DynamicObj"
+]
+    
 
 let tests_set = testList "Set" [
 
@@ -304,6 +365,7 @@ let tests_copyDynamicProperties = testList "CopyDynamicProperties" [
 ]
 
 let main = testList "DynamicObj" [
+    tests_tryGetTypedValue
     tests_set
     tests_remove
     tests_formatString


### PR DESCRIPTION
Generic type annotations are not supported at runtime in js and py. But: by inlining, Fable allows the function to be transpiled against all type cases that appear throughout the transpilation. 
Inlining is only possible for functions in Fable, so instead of fixing the member, I propose this new function in the `DynObj` module.

workaround for #26 