### PR TITLE
Fix System.Dynamic.DynamicObject based Serialization via Newtonsoft.Json

### DIFF
--- a/.github/workflows/build-and-deploy-docs.yml
+++ b/.github/workflows/build-and-deploy-docs.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
-    - name: Setup .NET 6
-      uses: actions/setup-dotnet@v1
+      uses: actions/checkout@v4
+    - name: Setup .NET 8
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '6.x.x'
+        dotnet-version: '8.x.x'
     - name: make script executable
       run: chmod u+x build.sh
     - name: Restore tools

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,7 +21,7 @@ jobs:
   
     # SETUP .NET
     - name: Setup .NET
-      uses: actions/setup-dotnet@4
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.x.x
     - name: Restore fable

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
   
     # SETUP .NET
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@4
       with:
-        dotnet-version: 6.x.x
+        dotnet-version: 8.x.x
     - name: Restore fable
       run: dotnet tool restore
 

--- a/build/BasicTasks.fs
+++ b/build/BasicTasks.fs
@@ -159,5 +159,18 @@ let clean = BuildTask.create "Clean" [] {
 
 let build = BuildTask.create "Build" [clean] {
     solutionFile
-    |> DotNet.build id
+    |> DotNet.build (fun p ->
+            let msBuildParams =
+                {p.MSBuildParams with 
+                    Properties = ([
+                        "warnon", "3390"
+                    ])
+                    DisableInternalBinLog = true
+                }
+            {
+                p with 
+                    MSBuildParams = msBuildParams
+            }
+            |> DotNet.Options.withCustomParams (Some "-tl")
+        )
 }

--- a/build/PackageTasks.fs
+++ b/build/PackageTasks.fs
@@ -30,6 +30,7 @@ module BundleDotNet =
                         "Version",versionTag
                         "PackageReleaseNotes",  (ProjectInfo.release.Notes |> List.map replaceCommitLink |> String.toLines )
                     ] @ p.MSBuildParams.Properties)
+                    DisableInternalBinLog = true
                 }
             {
                 p with 

--- a/build/TestTasks.fs
+++ b/build/TestTasks.fs
@@ -61,27 +61,3 @@ let runTests = BuildTask.createEmpty "RunTests" [
     RunTests.runTestsDotnet
     
     ]
-
-
-
-// to do: use this once we have actual tests
-let runTestsWithCodeCov = BuildTask.create "RunTestsWithCodeCov" [clean; build] {
-    let standardParams = Fake.DotNet.MSBuild.CliArguments.Create ()
-    testProjects
-    |> Seq.iter(fun testProject -> 
-        Fake.DotNet.DotNet.test(fun testParams ->
-            {
-                testParams with
-                    MSBuildParams = {
-                        standardParams with
-                            Properties = [
-                                "AltCover","true"
-                                "AltCoverCobertura","../../codeCov.xml"
-                                "AltCoverForce","true"
-                            ]
-                    };
-                    Logger = Some "console;verbosity=detailed"
-            }
-        ) testProject
-    )
-}

--- a/build/build.fsproj
+++ b/build/build.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
@@ -19,15 +19,15 @@
 
   <ItemGroup>
     <PackageReference Include="BlackFox.Fake.BuildTask" Version="0.1.3" />
-    <PackageReference Include="Fake.Api.Github" Version="6.0.0" />
-    <PackageReference Include="Fake.Core.Process" Version="6.0.0" />
-    <PackageReference Include="Fake.Core.ReleaseNotes" Version="6.0.0" />
-    <PackageReference Include="Fake.Core.Target" Version="6.0.0" />
-    <PackageReference Include="Fake.DotNet.Cli" Version="6.0.0" />
-    <PackageReference Include="Fake.DotNet.MSBuild" Version="6.0.0" />
-    <PackageReference Include="Fake.IO.FileSystem" Version="6.0.0" />
-    <PackageReference Include="Fake.JavaScript.Npm" Version="6.0.0" />
-    <PackageReference Include="Fake.Tools.Git" Version="6.0.0" />
+    <PackageReference Include="Fake.Api.Github" Version="6.1.1" />
+    <PackageReference Include="Fake.Core.Process" Version="6.1.1" />
+    <PackageReference Include="Fake.Core.ReleaseNotes" Version="6.1.1" />
+    <PackageReference Include="Fake.Core.Target" Version="6.1.1" />
+    <PackageReference Include="Fake.DotNet.Cli" Version="6.1.1" />
+    <PackageReference Include="Fake.DotNet.MSBuild" Version="6.1.1" />
+    <PackageReference Include="Fake.IO.FileSystem" Version="6.1.1" />
+    <PackageReference Include="Fake.JavaScript.Npm" Version="6.1.1" />
+    <PackageReference Include="Fake.Tools.Git" Version="6.1.1" />
     <PackageReference Include="Fake.Extensions.Release" Version="1.0.0" />
 
   </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100",
+    "version": "8.0.100",
     "rollForward": "latestMinor"
   }
 }

--- a/src/DynamicObj.Immutable/DynamicObj.Immutable.fsproj
+++ b/src/DynamicObj.Immutable/DynamicObj.Immutable.fsproj
@@ -30,6 +30,7 @@
   
   <ItemGroup>
     <PackageReference Include="Fable.Core" Version="4.3.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/DynamicObj.Immutable/DynamicObj.Immutable.fsproj
+++ b/src/DynamicObj.Immutable/DynamicObj.Immutable.fsproj
@@ -30,7 +30,6 @@
   
   <ItemGroup>
     <PackageReference Include="Fable.Core" Version="4.3.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/DynamicObj/DynamicObj.fs
+++ b/src/DynamicObj/DynamicObj.fs
@@ -2,11 +2,6 @@
 
 #if !FABLE_COMPILER
 open System.Dynamic
-open Newtonsoft.Json
-open Newtonsoft.Json.Serialization
-open Newtonsoft.Json.Converters
-open Newtonsoft.Json.Linq
-open System.Runtime.Serialization
 #endif
 
 open System.Collections.Generic

--- a/src/DynamicObj/DynamicObj.fs
+++ b/src/DynamicObj/DynamicObj.fs
@@ -1,15 +1,18 @@
 ﻿namespace DynamicObj
 
-//open System.Dynamic
+#if !FABLE_COMPILER
+open System.Dynamic
+#endif
+
 open System.Collections.Generic
 open Fable.Core
 
 [<AttachMembers>]
 type DynamicObj() = 
     
-    //#if !FABLE_COMPILER
-    //inherit DynamicObject()
-    //#endif
+    #if !FABLE_COMPILER
+    inherit DynamicObject()
+    #endif
 
     let mutable properties = new Dictionary<string, obj>()
 

--- a/src/DynamicObj/DynamicObj.fsproj
+++ b/src/DynamicObj/DynamicObj.fsproj
@@ -38,6 +38,7 @@
   
   <ItemGroup>
     <PackageReference Include="Fable.Core" Version="4.3.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DynamicObj/DynamicObj.fsproj
+++ b/src/DynamicObj/DynamicObj.fsproj
@@ -38,7 +38,6 @@
   
   <ItemGroup>
     <PackageReference Include="Fable.Core" Version="4.3.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DynamicObj/DynamicObj.fsproj
+++ b/src/DynamicObj/DynamicObj.fsproj
@@ -38,7 +38,6 @@
   
   <ItemGroup>
     <PackageReference Include="Fable.Core" Version="4.3.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/DynamicObject.Immutable.Tests/DynamicObject.Immutable.Tests.fsproj
+++ b/tests/DynamicObject.Immutable.Tests/DynamicObject.Immutable.Tests.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>

--- a/tests/DynamicObject.Tests/DynamicObject.Tests.fsproj
+++ b/tests/DynamicObject.Tests/DynamicObject.Tests.fsproj
@@ -32,6 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <ProjectReference Include="..\..\src\DynamicObj\DynamicObj.fsproj" />
   </ItemGroup>
 

--- a/tests/DynamicObject.Tests/DynamicObject.Tests.fsproj
+++ b/tests/DynamicObject.Tests/DynamicObject.Tests.fsproj
@@ -13,12 +13,14 @@
     <Compile Include="Interface.fs" />
     <Compile Include="DynamicObjs.fs" />
     <Compile Include="DynObj.fs" />
+    <Compile Include="Serialization.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Fable.Pyxpecto" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/DynamicObject.Tests/DynamicObject.Tests.fsproj
+++ b/tests/DynamicObject.Tests/DynamicObject.Tests.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <GenerateProgramFile>false</GenerateProgramFile>
@@ -20,7 +20,6 @@
   <ItemGroup>
     <PackageReference Include="Fable.Pyxpecto" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/DynamicObject.Tests/Main.fs
+++ b/tests/DynamicObject.Tests/Main.fs
@@ -8,6 +8,7 @@ let all = testSequenced <| testList "DynamicObj" [
     DynObj.Tests.main
     Inheritance.Tests.main
     Interface.Tests.main
+    Serialization.Tests.main
 ]
 
 [<EntryPoint>]

--- a/tests/DynamicObject.Tests/Serialization.fs
+++ b/tests/DynamicObject.Tests/Serialization.fs
@@ -11,30 +11,85 @@ open Newtonsoft.Json
 
 open DynamicObj
 
-let test_object = 
+let test_dynobj = 
     let obj = new DynamicObj()
-    obj.SetProperty("string", "yes")
-    obj.SetProperty("number", 69)
-    obj.SetProperty("boolean", true)
-    obj.SetProperty("array", ["First"; "Second"])
+    obj.SetProperty("dynamic_string", "yes")
+    obj.SetProperty("dynamic_number", 69)
+    obj.SetProperty("dynamic_boolean", true)
+    obj.SetProperty("dynamic_array", ["First"; "Second"])
     obj.SetProperty(
-        "object", 
+        "dynamic_object", 
             let tmp = new DynamicObj()
             tmp.SetProperty("inner", "yup")
+            tmp
         )
     obj
 
-let tests_newtonsoft = testList "Newtonsoft (.NET)" [
-#if !FABLE_COMPILER
-    ftestCase "Serialize" <| fun _ ->
-        let actual = JsonConvert.SerializeObject(test_object)
-        Expect.equal actual """{"string":"yes","number":69,"boolean":true,"array":["First","Second"],"object":{"inner":"yup"}}""" ""
+type DerivedClass1(staticProp: string) =
+    inherit DynamicObj()
+    member this.StaticProp = staticProp
 
-    testCase "Deserialize" <| fun _ ->
-        ()
-#endif
+type DerivedClass2(
+    staticString: string,
+    staticNumber: float,
+    staticBoolean: bool,
+    staticArray: string list,
+    staticObject: DynamicObj
+) =
+    inherit DynamicObj()
+    member this.StaticString = staticString
+    member this.StaticNumber = staticNumber
+    member this.StaticBoolean = staticBoolean
+    member this.StaticArray = staticArray
+    member this.StaticObject = staticObject
+
+let test_derived_1 = 
+    let obj = DerivedClass1("lol")
+    obj.SetProperty("dynamicProp", 42)
+    obj
+
+let test_derived_2 = 
+    let obj = DerivedClass2(
+        "lol",
+        42.0,
+        true,
+        ["First"; "Second"],
+        test_derived_1
+    )
+    obj.SetProperty("dynamic_string", "yes")
+    obj.SetProperty("dynamic_number", 69)
+    obj.SetProperty("dynamic_boolean", true)
+    obj.SetProperty("dynamic_array", ["First"; "Second"])
+    obj.SetProperty(
+        "dynamic_object", 
+            let tmp = new DynamicObj()
+            tmp.SetProperty("inner", "yup")
+            tmp
+        )
+    obj
+
+#if !FABLE_COMPILER
+let tests_newtonsoft = testList "Newtonsoft (.NET)" [
+    testCase "Serialize DynamicObj" <| fun _ ->
+        let actual = JsonConvert.SerializeObject(test_dynobj)
+        Expect.equal actual """{"dynamic_string":"yes","dynamic_number":69,"dynamic_boolean":true,"dynamic_array":["First","Second"],"dynamic_object":{"inner":"yup"}}""" ""
+
+    testCase "Serialize simplederived class from DynamicObj" <| fun _ ->
+        let actual = JsonConvert.SerializeObject(test_derived_1)
+        Expect.equal actual """{"StaticProp":"lol","dynamicProp":42}""" ""
+
+    testCase "Serialize complex derived class from DynamicObj" <| fun _ ->
+        let actual = JsonConvert.SerializeObject(test_derived_2)
+        Expect.equal actual """{"StaticString":"lol","StaticNumber":42.0,"StaticBoolean":true,"StaticArray":["First","Second"],"StaticObject":{"StaticProp":"lol","dynamicProp":42},"dynamic_string":"yes","dynamic_number":69,"dynamic_boolean":true,"dynamic_array":["First","Second"],"dynamic_object":{"inner":"yup"}}""" ""
 ]
+#endif
+
+// eventually, we want a transpilable, custom serialization
+let tests_custom = testList "Custom" []
 
 let main = testList "Serialization" [
+    tests_custom
+    #if !FABLE_COMPILER
     tests_newtonsoft
+    #endif
 ]

--- a/tests/DynamicObject.Tests/Serialization.fs
+++ b/tests/DynamicObject.Tests/Serialization.fs
@@ -1,0 +1,40 @@
+﻿module Serialization.Tests
+
+open System
+open System.Collections.Generic
+open Fable.Pyxpecto
+open DynamicObj
+
+#if !FABLE_COMPILER
+open Newtonsoft.Json
+#endif
+
+open DynamicObj
+
+let test_object = 
+    let obj = new DynamicObj()
+    obj.SetProperty("string", "yes")
+    obj.SetProperty("number", 69)
+    obj.SetProperty("boolean", true)
+    obj.SetProperty("array", ["First"; "Second"])
+    obj.SetProperty(
+        "object", 
+            let tmp = new DynamicObj()
+            tmp.SetProperty("inner", "yup")
+        )
+    obj
+
+let tests_newtonsoft = testList "Newtonsoft (.NET)" [
+#if !FABLE_COMPILER
+    ftestCase "Serialize" <| fun _ ->
+        let actual = JsonConvert.SerializeObject(test_object)
+        Expect.equal actual """{"string":"yes","number":69,"boolean":true,"array":["First","Second"],"object":{"inner":"yup"}}""" ""
+
+    testCase "Deserialize" <| fun _ ->
+        ()
+#endif
+]
+
+let main = testList "Serialization" [
+    tests_newtonsoft
+]

--- a/tests/DynamicObject.Tests/Serialization.fs
+++ b/tests/DynamicObject.Tests/Serialization.fs
@@ -5,10 +5,6 @@ open System.Collections.Generic
 open Fable.Pyxpecto
 open DynamicObj
 
-#if !FABLE_COMPILER
-open Newtonsoft.Json
-#endif
-
 open DynamicObj
 
 let test_dynobj = 
@@ -71,15 +67,29 @@ let test_derived_2 =
 #if !FABLE_COMPILER
 let tests_newtonsoft = testList "Newtonsoft (.NET)" [
     testCase "Serialize DynamicObj" <| fun _ ->
-        let actual = JsonConvert.SerializeObject(test_dynobj)
+        let actual = Newtonsoft.Json.JsonConvert.SerializeObject(test_dynobj)
         Expect.equal actual """{"dynamic_string":"yes","dynamic_number":69,"dynamic_boolean":true,"dynamic_array":["First","Second"],"dynamic_object":{"inner":"yup"}}""" ""
 
     testCase "Serialize simplederived class from DynamicObj" <| fun _ ->
-        let actual = JsonConvert.SerializeObject(test_derived_1)
+        let actual = Newtonsoft.Json.JsonConvert.SerializeObject(test_derived_1)
         Expect.equal actual """{"StaticProp":"lol","dynamicProp":42}""" ""
 
     testCase "Serialize complex derived class from DynamicObj" <| fun _ ->
-        let actual = JsonConvert.SerializeObject(test_derived_2)
+        let actual = Newtonsoft.Json.JsonConvert.SerializeObject(test_derived_2)
+        Expect.equal actual """{"StaticString":"lol","StaticNumber":42.0,"StaticBoolean":true,"StaticArray":["First","Second"],"StaticObject":{"StaticProp":"lol","dynamicProp":42},"dynamic_string":"yes","dynamic_number":69,"dynamic_boolean":true,"dynamic_array":["First","Second"],"dynamic_object":{"inner":"yup"}}""" ""
+]
+
+let tests_system_text_json = ptestList "System.Text.Json (.NET)" [
+    testCase "Serialize DynamicObj" <| fun _ ->
+        let actual = System.Text.Json.JsonSerializer.Serialize(test_dynobj)
+        Expect.equal actual """{"dynamic_string":"yes","dynamic_number":69,"dynamic_boolean":true,"dynamic_array":["First","Second"],"dynamic_object":{"inner":"yup"}}""" ""
+
+    testCase "Serialize simplederived class from DynamicObj" <| fun _ ->
+        let actual = System.Text.Json.JsonSerializer.Serialize(test_derived_1)
+        Expect.equal actual """{"StaticProp":"lol","dynamicProp":42}""" ""
+
+    testCase "Serialize complex derived class from DynamicObj" <| fun _ ->
+        let actual = System.Text.Json.JsonSerializer.Serialize(test_derived_2)
         Expect.equal actual """{"StaticString":"lol","StaticNumber":42.0,"StaticBoolean":true,"StaticArray":["First","Second"],"StaticObject":{"StaticProp":"lol","dynamicProp":42},"dynamic_string":"yes","dynamic_number":69,"dynamic_boolean":true,"dynamic_array":["First","Second"],"dynamic_object":{"inner":"yup"}}""" ""
 ]
 #endif
@@ -91,5 +101,6 @@ let main = testList "Serialization" [
     tests_custom
     #if !FABLE_COMPILER
     tests_newtonsoft
+    tests_system_text_json
     #endif
 ]


### PR DESCRIPTION
This PR
- Updates the project to .NET 8 because why is it still 6
- fixes Newtonsoft.Json Serialization:
  - when not transpiling, inherit `System.Dynamic.DynamicObject`
  - add necessary overrides, especially `_.GetDynamicMemberNames()`
- adds basic serialization tests

