### PR TITLE
Deep copy improvements

### DIFF
--- a/src/DynamicObj/DynObj.fs
+++ b/src/DynamicObj/DynObj.fs
@@ -217,3 +217,33 @@ module DynObj =
     /// </summary>
     /// <param name="dynObj">The DynamicObj for which to print a formatted string for</param>
     let print (dynObj:DynamicObj) = printfn "%s" (dynObj |> format)
+
+    /// <summary>
+    /// function to deep copy a boxed object (if possible)
+    ///
+    /// The following cases are handled (in this precedence):
+    ///
+    /// - Basic F# types (bool, byte, sbyte, int16, uint16, int, uint, int64, uint64, nativeint, unativeint, float, float32, char, string, unit, decimal)
+    ///
+    /// - ResizeArrays and Dictionaries containing any combination of basic F# types
+    ///
+    /// - Dictionaries containing DynamicObj as keys or values in any combination with DynamicObj or basic F# types as keys or values
+    ///
+    /// - array&lt;DynamicObj&gt;, list&lt;DynamicObj&gt;, ResizeArray&lt;DynamicObj&gt;: These collections of DynamicObj are copied as a new collection with recursively deep copied elements.
+    ///
+    /// - System.ICloneable: If the property implements ICloneable, the Clone() method is called on the property.
+    ///
+    /// - DynamicObj (and derived classes): properties that are themselves DynamicObj instances are deep copied recursively.
+    ///   if a derived class has static properties (e.g. instance properties), these will be copied as dynamic properties on the new instance.
+    ///
+    /// Note on Classes that inherit from DynamicObj:
+    ///
+    /// Classes that inherit from DynamicObj will match the `DynamicObj` typecheck if they do not implement ICloneable.
+    /// The deep copied instances will be cast to DynamicObj with static/instance properties AND dynamic properties all set as dynamic properties.
+    /// It should be possible to 'recover' the original type by checking if the needed properties exist as dynamic properties,
+    /// and then passing them to the class constructor if needed.
+    /// </summary>
+    /// <param name="o">The object that should be deep copied</param>
+    /// <param name="includeInstanceProperties">Whether to include instance properties (= 'static' properties on the class) as dynamic properties on the new instance for matched DynamicObj.</param>
+    let tryDeepCopyObj (includeInstanceProperties:bool) (o:DynamicObj) =
+        CopyUtils.tryDeepCopyObj(o, includeInstanceProperties)

--- a/src/DynamicObj/DynamicObj.fs
+++ b/src/DynamicObj/DynamicObj.fs
@@ -269,6 +269,10 @@ type DynamicObj() =
     ///
     /// - Basic F# types (int, float, bool, string, char, byte, sbyte, int16, uint16, int32, uint32, int64, uint64, single, decimal)
     ///
+    /// - ResizeArrays and Dictionaries containing any combination of basic F# types
+    ///
+    /// - Dictionaries containing DynamicObj as keys or values in any combination with DynamicObj or basic F# types as keys or values
+    ///
     /// - array&lt;DynamicObj&gt;, list&lt;DynamicObj&gt;, ResizeArray&lt;DynamicObj&gt;: These collections of DynamicObj are copied as a new collection with recursively deep copied elements.
     ///
     /// - System.ICloneable: If the property implements ICloneable, the Clone() method is called on the property.
@@ -308,6 +312,10 @@ type DynamicObj() =
     /// The following cases are handled (in this precedence):
     ///
     /// - Basic F# types (int, float, bool, string, char, byte, sbyte, int16, uint16, int32, uint32, int64, uint64, single, decimal)
+    ///
+    /// - ResizeArrays and Dictionaries containing any combination of basic F# types
+    ///
+    /// - Dictionaries containing DynamicObj as keys or values in any combination with DynamicObj or basic F# types as keys or values
     ///
     /// - array&lt;DynamicObj&gt;, list&lt;DynamicObj&gt;, ResizeArray&lt;DynamicObj&gt;: These collections of DynamicObj are copied as a new collection with recursively deep copied elements.
     ///
@@ -395,11 +403,23 @@ and CopyUtils =
 
             // might be that we do not need this case, however if we remove it, some types will match the 
             // ICloneable case in transpiled code, which we'd like to prevent, so well keep it for now.
-            | :? int     | :? float   | :? bool    
-            | :? string  | :? char    | :? byte    
-            | :? sbyte   | :? int16   | :? uint16  
-            | :? int32   | :? uint32  | :? int64   
-            | :? uint64  | :? single  
+            // https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/basic-types
+            | :? bool
+            | :? byte
+            | :? sbyte 
+            | :? int16
+            | :? uint16
+            | :? int
+            | :? uint
+            | :? int64
+            | :? uint64
+            | :? nativeint
+            | :? unativeint
+            | :? float
+            | :? float32
+            | :? char
+            | :? string
+            | :? unit
                 -> o
 
             #if !FABLE_COMPILER_PYTHON
@@ -407,12 +427,442 @@ and CopyUtils =
             | :? decimal -> o
             #endif
 
+            // ResizeArrays are mutable and we need to copy them. For primitives, we can do this easily.
+            | :? ResizeArray<bool>       as r -> ResizeArray(r) |> box
+            | :? ResizeArray<byte>       as r -> ResizeArray(r) |> box
+            | :? ResizeArray<sbyte>      as r -> ResizeArray(r) |> box
+            | :? ResizeArray<int16>      as r -> ResizeArray(r) |> box
+            | :? ResizeArray<uint16>     as r -> ResizeArray(r) |> box
+            | :? ResizeArray<int>        as r -> ResizeArray(r) |> box
+            | :? ResizeArray<uint>       as r -> ResizeArray(r) |> box
+            | :? ResizeArray<int64>      as r -> ResizeArray(r) |> box
+            | :? ResizeArray<uint64>     as r -> ResizeArray(r) |> box
+            | :? ResizeArray<nativeint>  as r -> ResizeArray(r) |> box
+            | :? ResizeArray<unativeint> as r -> ResizeArray(r) |> box
+            | :? ResizeArray<float>      as r -> ResizeArray(r) |> box
+            | :? ResizeArray<float32>    as r -> ResizeArray(r) |> box
+            | :? ResizeArray<char>       as r -> ResizeArray(r) |> box
+            | :? ResizeArray<string>     as r -> ResizeArray(r) |> box
+            | :? ResizeArray<unit>       as r -> ResizeArray(r) |> box
+
+            // Dictionaries are mutable and we need to copy them. For primitives, we can do this easily, it is just a lot of work to write man
+            | :? Dictionary<bool,bool>         as dict -> Dictionary<bool,bool>(dict) |> box
+            | :? Dictionary<bool,byte>         as dict -> Dictionary<bool,byte>(dict) |> box
+            | :? Dictionary<bool,sbyte>        as dict -> Dictionary<bool,sbyte>(dict) |> box
+            | :? Dictionary<bool,int16>        as dict -> Dictionary<bool,int16>(dict) |> box
+            | :? Dictionary<bool,uint16>       as dict -> Dictionary<bool,uint16>(dict) |> box
+            | :? Dictionary<bool,int>          as dict -> Dictionary<bool,int>(dict) |> box
+            | :? Dictionary<bool,uint>         as dict -> Dictionary<bool,uint>(dict) |> box
+            | :? Dictionary<bool,int64>        as dict -> Dictionary<bool,int64>(dict) |> box
+            | :? Dictionary<bool,uint64>       as dict -> Dictionary<bool,uint64>(dict) |> box
+            | :? Dictionary<bool,nativeint>    as dict -> Dictionary<bool,nativeint>(dict) |> box
+            | :? Dictionary<bool,unativeint>   as dict -> Dictionary<bool,unativeint>(dict) |> box
+            | :? Dictionary<bool,float>        as dict -> Dictionary<bool,float>(dict) |> box
+            | :? Dictionary<bool,float32>      as dict -> Dictionary<bool,float32>(dict) |> box
+            | :? Dictionary<bool,char>         as dict -> Dictionary<bool,char>(dict) |> box
+            | :? Dictionary<bool,string>       as dict -> Dictionary<bool,string>(dict) |> box
+            | :? Dictionary<bool,unit>         as dict -> Dictionary<bool,unit>(dict) |> box
+            
+            | :? Dictionary<byte,bool>         as dict -> Dictionary<byte,bool>(dict) |> box
+            | :? Dictionary<byte,byte>         as dict -> Dictionary<byte,byte>(dict) |> box
+            | :? Dictionary<byte,sbyte>        as dict -> Dictionary<byte,sbyte>(dict) |> box
+            | :? Dictionary<byte,int16>        as dict -> Dictionary<byte,int16>(dict) |> box
+            | :? Dictionary<byte,uint16>       as dict -> Dictionary<byte,uint16>(dict) |> box
+            | :? Dictionary<byte,int>          as dict -> Dictionary<byte,int>(dict) |> box
+            | :? Dictionary<byte,uint>         as dict -> Dictionary<byte,uint>(dict) |> box
+            | :? Dictionary<byte,int64>        as dict -> Dictionary<byte,int64>(dict) |> box
+            | :? Dictionary<byte,uint64>       as dict -> Dictionary<byte,uint64>(dict) |> box
+            | :? Dictionary<byte,nativeint>    as dict -> Dictionary<byte,nativeint>(dict) |> box
+            | :? Dictionary<byte,unativeint>   as dict -> Dictionary<byte,unativeint>(dict) |> box
+            | :? Dictionary<byte,float>        as dict -> Dictionary<byte,float>(dict) |> box
+            | :? Dictionary<byte,float32>      as dict -> Dictionary<byte,float32>(dict) |> box
+            | :? Dictionary<byte,char>         as dict -> Dictionary<byte,char>(dict) |> box
+            | :? Dictionary<byte,string>       as dict -> Dictionary<byte,string>(dict) |> box
+            | :? Dictionary<byte,unit>         as dict -> Dictionary<byte,unit>(dict) |> box
+            
+            | :? Dictionary<sbyte,bool>         as dict -> Dictionary<sbyte,bool>(dict) |> box
+            | :? Dictionary<sbyte,byte>         as dict -> Dictionary<sbyte,byte>(dict) |> box
+            | :? Dictionary<sbyte,sbyte>        as dict -> Dictionary<sbyte,sbyte>(dict) |> box
+            | :? Dictionary<sbyte,int16>        as dict -> Dictionary<sbyte,int16>(dict) |> box
+            | :? Dictionary<sbyte,uint16>       as dict -> Dictionary<sbyte,uint16>(dict) |> box
+            | :? Dictionary<sbyte,int>          as dict -> Dictionary<sbyte,int>(dict) |> box
+            | :? Dictionary<sbyte,uint>         as dict -> Dictionary<sbyte,uint>(dict) |> box
+            | :? Dictionary<sbyte,int64>        as dict -> Dictionary<sbyte,int64>(dict) |> box
+            | :? Dictionary<sbyte,uint64>       as dict -> Dictionary<sbyte,uint64>(dict) |> box
+            | :? Dictionary<sbyte,nativeint>    as dict -> Dictionary<sbyte,nativeint>(dict) |> box
+            | :? Dictionary<sbyte,unativeint>   as dict -> Dictionary<sbyte,unativeint>(dict) |> box
+            | :? Dictionary<sbyte,float>        as dict -> Dictionary<sbyte,float>(dict) |> box
+            | :? Dictionary<sbyte,float32>      as dict -> Dictionary<sbyte,float32>(dict) |> box
+            | :? Dictionary<sbyte,char>         as dict -> Dictionary<sbyte,char>(dict) |> box
+            | :? Dictionary<sbyte,string>       as dict -> Dictionary<sbyte,string>(dict) |> box
+            | :? Dictionary<sbyte,unit>         as dict -> Dictionary<sbyte,unit>(dict) |> box
+            
+            | :? Dictionary<int16,bool>         as dict -> Dictionary<int16,bool>(dict) |> box
+            | :? Dictionary<int16,byte>         as dict -> Dictionary<int16,byte>(dict) |> box
+            | :? Dictionary<int16,sbyte>        as dict -> Dictionary<int16,sbyte>(dict) |> box
+            | :? Dictionary<int16,int16>        as dict -> Dictionary<int16,int16>(dict) |> box
+            | :? Dictionary<int16,uint16>       as dict -> Dictionary<int16,uint16>(dict) |> box
+            | :? Dictionary<int16,int>          as dict -> Dictionary<int16,int>(dict) |> box
+            | :? Dictionary<int16,uint>         as dict -> Dictionary<int16,uint>(dict) |> box
+            | :? Dictionary<int16,int64>        as dict -> Dictionary<int16,int64>(dict) |> box
+            | :? Dictionary<int16,uint64>       as dict -> Dictionary<int16,uint64>(dict) |> box
+            | :? Dictionary<int16,nativeint>    as dict -> Dictionary<int16,nativeint>(dict) |> box
+            | :? Dictionary<int16,unativeint>   as dict -> Dictionary<int16,unativeint>(dict) |> box
+            | :? Dictionary<int16,float>        as dict -> Dictionary<int16,float>(dict) |> box
+            | :? Dictionary<int16,float32>      as dict -> Dictionary<int16,float32>(dict) |> box
+            | :? Dictionary<int16,char>         as dict -> Dictionary<int16,char>(dict) |> box
+            | :? Dictionary<int16,string>       as dict -> Dictionary<int16,string>(dict) |> box
+            | :? Dictionary<int16,unit>         as dict -> Dictionary<int16,unit>(dict) |> box
+            
+            | :? Dictionary<uint16,bool>         as dict -> Dictionary<uint16,bool>(dict) |> box
+            | :? Dictionary<uint16,byte>         as dict -> Dictionary<uint16,byte>(dict) |> box
+            | :? Dictionary<uint16,sbyte>        as dict -> Dictionary<uint16,sbyte>(dict) |> box
+            | :? Dictionary<uint16,int16>        as dict -> Dictionary<uint16,int16>(dict) |> box
+            | :? Dictionary<uint16,uint16>       as dict -> Dictionary<uint16,uint16>(dict) |> box
+            | :? Dictionary<uint16,int>          as dict -> Dictionary<uint16,int>(dict) |> box
+            | :? Dictionary<uint16,uint>         as dict -> Dictionary<uint16,uint>(dict) |> box
+            | :? Dictionary<uint16,int64>        as dict -> Dictionary<uint16,int64>(dict) |> box
+            | :? Dictionary<uint16,uint64>       as dict -> Dictionary<uint16,uint64>(dict) |> box
+            | :? Dictionary<uint16,nativeint>    as dict -> Dictionary<uint16,nativeint>(dict) |> box
+            | :? Dictionary<uint16,unativeint>   as dict -> Dictionary<uint16,unativeint>(dict) |> box
+            | :? Dictionary<uint16,float>        as dict -> Dictionary<uint16,float>(dict) |> box
+            | :? Dictionary<uint16,float32>      as dict -> Dictionary<uint16,float32>(dict) |> box
+            | :? Dictionary<uint16,char>         as dict -> Dictionary<uint16,char>(dict) |> box
+            | :? Dictionary<uint16,string>       as dict -> Dictionary<uint16,string>(dict) |> box
+            | :? Dictionary<uint16,unit>         as dict -> Dictionary<uint16,unit>(dict) |> box
+            
+            | :? Dictionary<int,bool>         as dict -> Dictionary<int,bool>(dict) |> box
+            | :? Dictionary<int,byte>         as dict -> Dictionary<int,byte>(dict) |> box
+            | :? Dictionary<int,sbyte>        as dict -> Dictionary<int,sbyte>(dict) |> box
+            | :? Dictionary<int,int16>        as dict -> Dictionary<int,int16>(dict) |> box
+            | :? Dictionary<int,uint16>       as dict -> Dictionary<int,uint16>(dict) |> box
+            | :? Dictionary<int,int>          as dict -> Dictionary<int,int>(dict) |> box
+            | :? Dictionary<int,uint>         as dict -> Dictionary<int,uint>(dict) |> box
+            | :? Dictionary<int,int64>        as dict -> Dictionary<int,int64>(dict) |> box
+            | :? Dictionary<int,uint64>       as dict -> Dictionary<int,uint64>(dict) |> box
+            | :? Dictionary<int,nativeint>    as dict -> Dictionary<int,nativeint>(dict) |> box
+            | :? Dictionary<int,unativeint>   as dict -> Dictionary<int,unativeint>(dict) |> box
+            | :? Dictionary<int,float>        as dict -> Dictionary<int,float>(dict) |> box
+            | :? Dictionary<int,float32>      as dict -> Dictionary<int,float32>(dict) |> box
+            | :? Dictionary<int,char>         as dict -> Dictionary<int,char>(dict) |> box
+            | :? Dictionary<int,string>       as dict -> Dictionary<int,string>(dict) |> box
+            | :? Dictionary<int,unit>         as dict -> Dictionary<int,unit>(dict) |> box
+            
+            | :? Dictionary<uint,bool>         as dict -> Dictionary<uint,bool>(dict) |> box
+            | :? Dictionary<uint,byte>         as dict -> Dictionary<uint,byte>(dict) |> box
+            | :? Dictionary<uint,sbyte>        as dict -> Dictionary<uint,sbyte>(dict) |> box
+            | :? Dictionary<uint,int16>        as dict -> Dictionary<uint,int16>(dict) |> box
+            | :? Dictionary<uint,uint16>       as dict -> Dictionary<uint,uint16>(dict) |> box
+            | :? Dictionary<uint,int>          as dict -> Dictionary<uint,int>(dict) |> box
+            | :? Dictionary<uint,uint>         as dict -> Dictionary<uint,uint>(dict) |> box
+            | :? Dictionary<uint,int64>        as dict -> Dictionary<uint,int64>(dict) |> box
+            | :? Dictionary<uint,uint64>       as dict -> Dictionary<uint,uint64>(dict) |> box
+            | :? Dictionary<uint,nativeint>    as dict -> Dictionary<uint,nativeint>(dict) |> box
+            | :? Dictionary<uint,unativeint>   as dict -> Dictionary<uint,unativeint>(dict) |> box
+            | :? Dictionary<uint,float>        as dict -> Dictionary<uint,float>(dict) |> box
+            | :? Dictionary<uint,float32>      as dict -> Dictionary<uint,float32>(dict) |> box
+            | :? Dictionary<uint,char>         as dict -> Dictionary<uint,char>(dict) |> box
+            | :? Dictionary<uint,string>       as dict -> Dictionary<uint,string>(dict) |> box
+            | :? Dictionary<uint,unit>         as dict -> Dictionary<uint,unit>(dict) |> box
+            
+            | :? Dictionary<int64,bool>         as dict -> Dictionary<int64,bool>(dict) |> box
+            | :? Dictionary<int64,byte>         as dict -> Dictionary<int64,byte>(dict) |> box
+            | :? Dictionary<int64,sbyte>        as dict -> Dictionary<int64,sbyte>(dict) |> box
+            | :? Dictionary<int64,int16>        as dict -> Dictionary<int64,int16>(dict) |> box
+            | :? Dictionary<int64,uint16>       as dict -> Dictionary<int64,uint16>(dict) |> box
+            | :? Dictionary<int64,int>          as dict -> Dictionary<int64,int>(dict) |> box
+            | :? Dictionary<int64,uint>         as dict -> Dictionary<int64,uint>(dict) |> box
+            | :? Dictionary<int64,int64>        as dict -> Dictionary<int64,int64>(dict) |> box
+            | :? Dictionary<int64,uint64>       as dict -> Dictionary<int64,uint64>(dict) |> box
+            | :? Dictionary<int64,nativeint>    as dict -> Dictionary<int64,nativeint>(dict) |> box
+            | :? Dictionary<int64,unativeint>   as dict -> Dictionary<int64,unativeint>(dict) |> box
+            | :? Dictionary<int64,float>        as dict -> Dictionary<int64,float>(dict) |> box
+            | :? Dictionary<int64,float32>      as dict -> Dictionary<int64,float32>(dict) |> box
+            | :? Dictionary<int64,char>         as dict -> Dictionary<int64,char>(dict) |> box
+            | :? Dictionary<int64,string>       as dict -> Dictionary<int64,string>(dict) |> box
+            | :? Dictionary<int64,unit>         as dict -> Dictionary<int64,unit>(dict) |> box
+            
+            | :? Dictionary<uint64,bool>         as dict -> Dictionary<uint64,bool>(dict) |> box
+            | :? Dictionary<uint64,byte>         as dict -> Dictionary<uint64,byte>(dict) |> box
+            | :? Dictionary<uint64,sbyte>        as dict -> Dictionary<uint64,sbyte>(dict) |> box
+            | :? Dictionary<uint64,int16>        as dict -> Dictionary<uint64,int16>(dict) |> box
+            | :? Dictionary<uint64,uint16>       as dict -> Dictionary<uint64,uint16>(dict) |> box
+            | :? Dictionary<uint64,int>          as dict -> Dictionary<uint64,int>(dict) |> box
+            | :? Dictionary<uint64,uint>         as dict -> Dictionary<uint64,uint>(dict) |> box
+            | :? Dictionary<uint64,int64>        as dict -> Dictionary<uint64,int64>(dict) |> box
+            | :? Dictionary<uint64,uint64>       as dict -> Dictionary<uint64,uint64>(dict) |> box
+            | :? Dictionary<uint64,nativeint>    as dict -> Dictionary<uint64,nativeint>(dict) |> box
+            | :? Dictionary<uint64,unativeint>   as dict -> Dictionary<uint64,unativeint>(dict) |> box
+            | :? Dictionary<uint64,float>        as dict -> Dictionary<uint64,float>(dict) |> box
+            | :? Dictionary<uint64,float32>      as dict -> Dictionary<uint64,float32>(dict) |> box
+            | :? Dictionary<uint64,char>         as dict -> Dictionary<uint64,char>(dict) |> box
+            | :? Dictionary<uint64,string>       as dict -> Dictionary<uint64,string>(dict) |> box
+            | :? Dictionary<uint64,unit>         as dict -> Dictionary<uint64,unit>(dict) |> box
+            
+            | :? Dictionary<nativeint,bool>         as dict -> Dictionary<nativeint,bool>(dict) |> box
+            | :? Dictionary<nativeint,byte>         as dict -> Dictionary<nativeint,byte>(dict) |> box
+            | :? Dictionary<nativeint,sbyte>        as dict -> Dictionary<nativeint,sbyte>(dict) |> box
+            | :? Dictionary<nativeint,int16>        as dict -> Dictionary<nativeint,int16>(dict) |> box
+            | :? Dictionary<nativeint,uint16>       as dict -> Dictionary<nativeint,uint16>(dict) |> box
+            | :? Dictionary<nativeint,int>          as dict -> Dictionary<nativeint,int>(dict) |> box
+            | :? Dictionary<nativeint,uint>         as dict -> Dictionary<nativeint,uint>(dict) |> box
+            | :? Dictionary<nativeint,int64>        as dict -> Dictionary<nativeint,int64>(dict) |> box
+            | :? Dictionary<nativeint,uint64>       as dict -> Dictionary<nativeint,uint64>(dict) |> box
+            | :? Dictionary<nativeint,nativeint>    as dict -> Dictionary<nativeint,nativeint>(dict) |> box
+            | :? Dictionary<nativeint,unativeint>   as dict -> Dictionary<nativeint,unativeint>(dict) |> box
+            | :? Dictionary<nativeint,float>        as dict -> Dictionary<nativeint,float>(dict) |> box
+            | :? Dictionary<nativeint,float32>      as dict -> Dictionary<nativeint,float32>(dict) |> box
+            | :? Dictionary<nativeint,char>         as dict -> Dictionary<nativeint,char>(dict) |> box
+            | :? Dictionary<nativeint,string>       as dict -> Dictionary<nativeint,string>(dict) |> box
+            | :? Dictionary<nativeint,unit>         as dict -> Dictionary<nativeint,unit>(dict) |> box
+            
+            | :? Dictionary<unativeint,bool>         as dict -> Dictionary<unativeint,bool>(dict) |> box
+            | :? Dictionary<unativeint,byte>         as dict -> Dictionary<unativeint,byte>(dict) |> box
+            | :? Dictionary<unativeint,sbyte>        as dict -> Dictionary<unativeint,sbyte>(dict) |> box
+            | :? Dictionary<unativeint,int16>        as dict -> Dictionary<unativeint,int16>(dict) |> box
+            | :? Dictionary<unativeint,uint16>       as dict -> Dictionary<unativeint,uint16>(dict) |> box
+            | :? Dictionary<unativeint,int>          as dict -> Dictionary<unativeint,int>(dict) |> box
+            | :? Dictionary<unativeint,uint>         as dict -> Dictionary<unativeint,uint>(dict) |> box
+            | :? Dictionary<unativeint,int64>        as dict -> Dictionary<unativeint,int64>(dict) |> box
+            | :? Dictionary<unativeint,uint64>       as dict -> Dictionary<unativeint,uint64>(dict) |> box
+            | :? Dictionary<unativeint,nativeint>    as dict -> Dictionary<unativeint,nativeint>(dict) |> box
+            | :? Dictionary<unativeint,unativeint>   as dict -> Dictionary<unativeint,unativeint>(dict) |> box
+            | :? Dictionary<unativeint,float>        as dict -> Dictionary<unativeint,float>(dict) |> box
+            | :? Dictionary<unativeint,float32>      as dict -> Dictionary<unativeint,float32>(dict) |> box
+            | :? Dictionary<unativeint,char>         as dict -> Dictionary<unativeint,char>(dict) |> box
+            | :? Dictionary<unativeint,string>       as dict -> Dictionary<unativeint,string>(dict) |> box
+            | :? Dictionary<unativeint,unit>         as dict -> Dictionary<unativeint,unit>(dict) |> box
+            
+            | :? Dictionary<float,bool>         as dict -> Dictionary<float,bool>(dict) |> box
+            | :? Dictionary<float,byte>         as dict -> Dictionary<float,byte>(dict) |> box
+            | :? Dictionary<float,sbyte>        as dict -> Dictionary<float,sbyte>(dict) |> box
+            | :? Dictionary<float,int16>        as dict -> Dictionary<float,int16>(dict) |> box
+            | :? Dictionary<float,uint16>       as dict -> Dictionary<float,uint16>(dict) |> box
+            | :? Dictionary<float,int>          as dict -> Dictionary<float,int>(dict) |> box
+            | :? Dictionary<float,uint>         as dict -> Dictionary<float,uint>(dict) |> box
+            | :? Dictionary<float,int64>        as dict -> Dictionary<float,int64>(dict) |> box
+            | :? Dictionary<float,uint64>       as dict -> Dictionary<float,uint64>(dict) |> box
+            | :? Dictionary<float,nativeint>    as dict -> Dictionary<float,nativeint>(dict) |> box
+            | :? Dictionary<float,unativeint>   as dict -> Dictionary<float,unativeint>(dict) |> box
+            | :? Dictionary<float,float>        as dict -> Dictionary<float,float>(dict) |> box
+            | :? Dictionary<float,float32>      as dict -> Dictionary<float,float32>(dict) |> box
+            | :? Dictionary<float,char>         as dict -> Dictionary<float,char>(dict) |> box
+            | :? Dictionary<float,string>       as dict -> Dictionary<float,string>(dict) |> box
+            | :? Dictionary<float,unit>         as dict -> Dictionary<float,unit>(dict) |> box
+            
+            | :? Dictionary<float32,bool>         as dict -> Dictionary<float32,bool>(dict) |> box
+            | :? Dictionary<float32,byte>         as dict -> Dictionary<float32,byte>(dict) |> box
+            | :? Dictionary<float32,sbyte>        as dict -> Dictionary<float32,sbyte>(dict) |> box
+            | :? Dictionary<float32,int16>        as dict -> Dictionary<float32,int16>(dict) |> box
+            | :? Dictionary<float32,uint16>       as dict -> Dictionary<float32,uint16>(dict) |> box
+            | :? Dictionary<float32,int>          as dict -> Dictionary<float32,int>(dict) |> box
+            | :? Dictionary<float32,uint>         as dict -> Dictionary<float32,uint>(dict) |> box
+            | :? Dictionary<float32,int64>        as dict -> Dictionary<float32,int64>(dict) |> box
+            | :? Dictionary<float32,uint64>       as dict -> Dictionary<float32,uint64>(dict) |> box
+            | :? Dictionary<float32,nativeint>    as dict -> Dictionary<float32,nativeint>(dict) |> box
+            | :? Dictionary<float32,unativeint>   as dict -> Dictionary<float32,unativeint>(dict) |> box
+            | :? Dictionary<float32,float>        as dict -> Dictionary<float32,float>(dict) |> box
+            | :? Dictionary<float32,float32>      as dict -> Dictionary<float32,float32>(dict) |> box
+            | :? Dictionary<float32,char>         as dict -> Dictionary<float32,char>(dict) |> box
+            | :? Dictionary<float32,string>       as dict -> Dictionary<float32,string>(dict) |> box
+            | :? Dictionary<float32,unit>         as dict -> Dictionary<float32,unit>(dict) |> box
+            
+            | :? Dictionary<char,bool>         as dict -> Dictionary<char,bool>(dict) |> box
+            | :? Dictionary<char,byte>         as dict -> Dictionary<char,byte>(dict) |> box
+            | :? Dictionary<char,sbyte>        as dict -> Dictionary<char,sbyte>(dict) |> box
+            | :? Dictionary<char,int16>        as dict -> Dictionary<char,int16>(dict) |> box
+            | :? Dictionary<char,uint16>       as dict -> Dictionary<char,uint16>(dict) |> box
+            | :? Dictionary<char,int>          as dict -> Dictionary<char,int>(dict) |> box
+            | :? Dictionary<char,uint>         as dict -> Dictionary<char,uint>(dict) |> box
+            | :? Dictionary<char,int64>        as dict -> Dictionary<char,int64>(dict) |> box
+            | :? Dictionary<char,uint64>       as dict -> Dictionary<char,uint64>(dict) |> box
+            | :? Dictionary<char,nativeint>    as dict -> Dictionary<char,nativeint>(dict) |> box
+            | :? Dictionary<char,unativeint>   as dict -> Dictionary<char,unativeint>(dict) |> box
+            | :? Dictionary<char,float>        as dict -> Dictionary<char,float>(dict) |> box
+            | :? Dictionary<char,float32>      as dict -> Dictionary<char,float32>(dict) |> box
+            | :? Dictionary<char,char>         as dict -> Dictionary<char,char>(dict) |> box
+            | :? Dictionary<char,string>       as dict -> Dictionary<char,string>(dict) |> box
+            | :? Dictionary<char,unit>         as dict -> Dictionary<char,unit>(dict) |> box
+            
+            | :? Dictionary<string,bool>         as dict -> Dictionary<string,bool>(dict) |> box
+            | :? Dictionary<string,byte>         as dict -> Dictionary<string,byte>(dict) |> box
+            | :? Dictionary<string,sbyte>        as dict -> Dictionary<string,sbyte>(dict) |> box
+            | :? Dictionary<string,int16>        as dict -> Dictionary<string,int16>(dict) |> box
+            | :? Dictionary<string,uint16>       as dict -> Dictionary<string,uint16>(dict) |> box
+            | :? Dictionary<string,int>          as dict -> Dictionary<string,int>(dict) |> box
+            | :? Dictionary<string,uint>         as dict -> Dictionary<string,uint>(dict) |> box
+            | :? Dictionary<string,int64>        as dict -> Dictionary<string,int64>(dict) |> box
+            | :? Dictionary<string,uint64>       as dict -> Dictionary<string,uint64>(dict) |> box
+            | :? Dictionary<string,nativeint>    as dict -> Dictionary<string,nativeint>(dict) |> box
+            | :? Dictionary<string,unativeint>   as dict -> Dictionary<string,unativeint>(dict) |> box
+            | :? Dictionary<string,float>        as dict -> Dictionary<string,float>(dict) |> box
+            | :? Dictionary<string,float32>      as dict -> Dictionary<string,float32>(dict) |> box
+            | :? Dictionary<string,char>         as dict -> Dictionary<string,char>(dict) |> box
+            | :? Dictionary<string,string>       as dict -> Dictionary<string,string>(dict) |> box
+            | :? Dictionary<string,unit>         as dict -> Dictionary<string,unit>(dict) |> box
+            
+            | :? Dictionary<unit,bool>         as dict -> Dictionary<unit,bool>(dict) |> box
+            | :? Dictionary<unit,byte>         as dict -> Dictionary<unit,byte>(dict) |> box
+            | :? Dictionary<unit,sbyte>        as dict -> Dictionary<unit,sbyte>(dict) |> box
+            | :? Dictionary<unit,int16>        as dict -> Dictionary<unit,int16>(dict) |> box
+            | :? Dictionary<unit,uint16>       as dict -> Dictionary<unit,uint16>(dict) |> box
+            | :? Dictionary<unit,int>          as dict -> Dictionary<unit,int>(dict) |> box
+            | :? Dictionary<unit,uint>         as dict -> Dictionary<unit,uint>(dict) |> box
+            | :? Dictionary<unit,int64>        as dict -> Dictionary<unit,int64>(dict) |> box
+            | :? Dictionary<unit,uint64>       as dict -> Dictionary<unit,uint64>(dict) |> box
+            | :? Dictionary<unit,nativeint>    as dict -> Dictionary<unit,nativeint>(dict) |> box
+            | :? Dictionary<unit,unativeint>   as dict -> Dictionary<unit,unativeint>(dict) |> box
+            | :? Dictionary<unit,float>        as dict -> Dictionary<unit,float>(dict) |> box
+            | :? Dictionary<unit,float32>      as dict -> Dictionary<unit,float32>(dict) |> box
+            | :? Dictionary<unit,char>         as dict -> Dictionary<unit,char>(dict) |> box
+            | :? Dictionary<unit,string>       as dict -> Dictionary<unit,string>(dict) |> box
+            | :? Dictionary<unit,unit>         as dict -> Dictionary<unit,unit>(dict) |> box
+
+            // same for dictionaries containing DynamicObj as value
+            | :? Dictionary<bool,DynamicObj>         as dict -> 
+                let newDict = Dictionary<bool,DynamicObj>()
+                for kv in dict do newDict.Add(kv.Key, tryDeepCopyObj kv.Value :?> DynamicObj)
+                newDict |> box
+            | :? Dictionary<byte,DynamicObj>         as dict -> 
+                let newDict = Dictionary<byte,DynamicObj>()
+                for kv in dict do newDict.Add(kv.Key, tryDeepCopyObj kv.Value :?> DynamicObj)
+                newDict |> box
+            | :? Dictionary<sbyte ,DynamicObj>       as dict -> 
+                let newDict = Dictionary<sbyte ,DynamicObj>()
+                for kv in dict do newDict.Add(kv.Key, tryDeepCopyObj kv.Value :?> DynamicObj)
+                newDict |> box
+            | :? Dictionary<int16,DynamicObj>        as dict -> 
+                let newDict = Dictionary<int16,DynamicObj>()
+                for kv in dict do newDict.Add(kv.Key, tryDeepCopyObj kv.Value :?> DynamicObj)
+                newDict |> box
+            | :? Dictionary<uint16,DynamicObj>       as dict -> 
+                let newDict = Dictionary<uint16,DynamicObj>()
+                for kv in dict do newDict.Add(kv.Key, tryDeepCopyObj kv.Value :?> DynamicObj)
+                newDict |> box
+            | :? Dictionary<int,DynamicObj>          as dict -> 
+                let newDict = Dictionary<int,DynamicObj>()
+                for kv in dict do newDict.Add(kv.Key, tryDeepCopyObj kv.Value :?> DynamicObj)
+                newDict |> box
+            | :? Dictionary<uint,DynamicObj>         as dict -> 
+                let newDict = Dictionary<uint,DynamicObj>()
+                for kv in dict do newDict.Add(kv.Key, tryDeepCopyObj kv.Value :?> DynamicObj)
+                newDict |> box
+            | :? Dictionary<int64,DynamicObj>        as dict -> 
+                let newDict = Dictionary<int64,DynamicObj>()
+                for kv in dict do newDict.Add(kv.Key, tryDeepCopyObj kv.Value :?> DynamicObj)
+                newDict |> box
+            | :? Dictionary<uint64,DynamicObj>       as dict -> 
+                let newDict = Dictionary<uint64,DynamicObj>()
+                for kv in dict do newDict.Add(kv.Key, tryDeepCopyObj kv.Value :?> DynamicObj)
+                newDict |> box
+            | :? Dictionary<nativeint,DynamicObj>    as dict -> 
+                let newDict = Dictionary<nativeint,DynamicObj>()
+                for kv in dict do newDict.Add(kv.Key, tryDeepCopyObj kv.Value :?> DynamicObj)
+                newDict |> box
+            | :? Dictionary<unativeint,DynamicObj>   as dict -> 
+                let newDict = Dictionary<unativeint,DynamicObj>()
+                for kv in dict do newDict.Add(kv.Key, tryDeepCopyObj kv.Value :?> DynamicObj)
+                newDict |> box
+            | :? Dictionary<float,DynamicObj>        as dict -> 
+                let newDict = Dictionary<float,DynamicObj>()
+                for kv in dict do newDict.Add(kv.Key, tryDeepCopyObj kv.Value :?> DynamicObj)
+                newDict |> box
+            | :? Dictionary<float32,DynamicObj>      as dict -> 
+                let newDict = Dictionary<float32,DynamicObj>()
+                for kv in dict do newDict.Add(kv.Key, tryDeepCopyObj kv.Value :?> DynamicObj)
+                newDict |> box
+            | :? Dictionary<char,DynamicObj>         as dict -> 
+                let newDict = Dictionary<char,DynamicObj>()
+                for kv in dict do newDict.Add(kv.Key, tryDeepCopyObj kv.Value :?> DynamicObj)
+                newDict |> box
+            | :? Dictionary<string,DynamicObj>       as dict -> 
+                let newDict = Dictionary<string,DynamicObj>()
+                for kv in dict do newDict.Add(kv.Key, tryDeepCopyObj kv.Value :?> DynamicObj)
+                newDict |> box
+            | :? Dictionary<unit,DynamicObj>         as dict -> 
+                let newDict = Dictionary<unit,DynamicObj>()
+                for kv in dict do newDict.Add(kv.Key, tryDeepCopyObj kv.Value :?> DynamicObj)
+                newDict |> box
+
+            // And for dictionaries containing DynamicObj as key
+            | :? Dictionary<DynamicObj,bool>         as dict -> 
+                let newDict = Dictionary<DynamicObj,bool>()
+                for kv in dict do newDict.Add(tryDeepCopyObj kv.Key :?> DynamicObj, kv.Value)
+                newDict |> box
+            | :? Dictionary<DynamicObj,byte>         as dict -> 
+                let newDict = Dictionary<DynamicObj,byte>()
+                for kv in dict do newDict.Add(tryDeepCopyObj kv.Key :?> DynamicObj, kv.Value)
+                newDict |> box
+            | :? Dictionary<DynamicObj,sbyte>       as dict -> 
+                let newDict = Dictionary<DynamicObj,sbyte>()
+                for kv in dict do newDict.Add(tryDeepCopyObj kv.Key :?> DynamicObj, kv.Value)
+                newDict |> box
+            | :? Dictionary<DynamicObj,int16>        as dict -> 
+                let newDict = Dictionary<DynamicObj,int16>()
+                for kv in dict do newDict.Add(tryDeepCopyObj kv.Key :?> DynamicObj, kv.Value)
+                newDict |> box
+            | :? Dictionary<DynamicObj,uint16>       as dict -> 
+                let newDict = Dictionary<DynamicObj,uint16>()
+                for kv in dict do newDict.Add(tryDeepCopyObj kv.Key :?> DynamicObj, kv.Value)
+                newDict |> box
+            | :? Dictionary<DynamicObj,int>          as dict -> 
+                let newDict = Dictionary<DynamicObj,int>()
+                for kv in dict do newDict.Add(tryDeepCopyObj kv.Key :?> DynamicObj, kv.Value)
+                newDict |> box
+            | :? Dictionary<DynamicObj,uint>         as dict -> 
+                let newDict = Dictionary<DynamicObj,uint>()
+                for kv in dict do newDict.Add(tryDeepCopyObj kv.Key :?> DynamicObj, kv.Value)
+                newDict |> box
+            | :? Dictionary<DynamicObj,int64>        as dict -> 
+                let newDict = Dictionary<DynamicObj,int64>()
+                for kv in dict do newDict.Add(tryDeepCopyObj kv.Key :?> DynamicObj, kv.Value)
+                newDict |> box
+            | :? Dictionary<DynamicObj,uint64>       as dict -> 
+                let newDict = Dictionary<DynamicObj,uint64>()
+                for kv in dict do newDict.Add(tryDeepCopyObj kv.Key :?> DynamicObj, kv.Value)
+                newDict |> box
+            | :? Dictionary<DynamicObj,nativeint>    as dict -> 
+                let newDict = Dictionary<DynamicObj,nativeint>()
+                for kv in dict do newDict.Add(tryDeepCopyObj kv.Key :?> DynamicObj, kv.Value)
+                newDict |> box
+            | :? Dictionary<DynamicObj,unativeint>   as dict -> 
+                let newDict = Dictionary<DynamicObj,unativeint>()
+                for kv in dict do newDict.Add(tryDeepCopyObj kv.Key :?> DynamicObj, kv.Value)
+                newDict |> box
+            | :? Dictionary<DynamicObj,float>        as dict -> 
+                let newDict = Dictionary<DynamicObj,float>()
+                for kv in dict do newDict.Add(tryDeepCopyObj kv.Key :?> DynamicObj, kv.Value)
+                newDict |> box
+            | :? Dictionary<DynamicObj,float32>      as dict -> 
+                let newDict = Dictionary<DynamicObj,float32>()
+                for kv in dict do newDict.Add(tryDeepCopyObj kv.Key :?> DynamicObj, kv.Value)
+                newDict |> box
+            | :? Dictionary<DynamicObj,char>         as dict -> 
+                let newDict = Dictionary<DynamicObj,char>()
+                for kv in dict do newDict.Add(tryDeepCopyObj kv.Key :?> DynamicObj, kv.Value)
+                newDict |> box
+            | :? Dictionary<DynamicObj,string>       as dict -> 
+                let newDict = Dictionary<DynamicObj,string>()
+                for kv in dict do newDict.Add(tryDeepCopyObj kv.Key :?> DynamicObj, kv.Value)
+                newDict |> box
+            | :? Dictionary<DynamicObj,unit>         as dict -> 
+                let newDict = Dictionary<DynamicObj,unit>()
+                for kv in dict do newDict.Add(tryDeepCopyObj kv.Key :?> DynamicObj, kv.Value)
+                newDict |> box            
+            | :? Dictionary<DynamicObj,DynamicObj>         as dict -> 
+                let newDict = Dictionary<DynamicObj,DynamicObj>()
+                for kv in dict do newDict.Add(tryDeepCopyObj kv.Key :?> DynamicObj, tryDeepCopyObj kv.Value :?> DynamicObj)
+                newDict |> box
+
+            // These collections of DynamicObj can be cloned recursively
+            | :? ResizeArray<DynamicObj> as dyns ->
+                box (ResizeArray([for dyn in dyns -> tryDeepCopyObj dyn :?> DynamicObj]))
             | :? array<DynamicObj> as dyns ->
                 box [|for dyn in dyns -> tryDeepCopyObj dyn :?> DynamicObj|]
             | :? list<DynamicObj> as dyns ->
                 box [for dyn in dyns -> tryDeepCopyObj dyn :?> DynamicObj]
-            | :? ResizeArray<DynamicObj> as dyns ->
-                box (ResizeArray([for dyn in dyns -> tryDeepCopyObj dyn :?> DynamicObj]))
+
+            // Fable compilable version of typematching against implemented IClonable
             #if FABLE_COMPILER_JAVASCRIPT || FABLE_COMPILER_TYPESCRIPT
             | o when FableJS.Interfaces.implementsICloneable o -> FableJS.Interfaces.cloneICloneable o
             #endif
@@ -428,7 +878,7 @@ and CopyUtils =
                 let newDyn = DynamicObj()
                 // might want to keep instance props as dynamic props on copy
                 for kv in (dyn.GetProperties(true)) do
-                    newDyn.SetProperty(kv.Key, tryDeepCopyObj kv.Value)
+                    newDyn.SetProperty(kv.Key, tryDeepCopyObj kv.Value :?> DynamicObj)
                 box newDyn
             | _ -> o
 

--- a/src/DynamicObj/DynamicObj.fs
+++ b/src/DynamicObj/DynamicObj.fs
@@ -909,7 +909,7 @@ and CopyUtils =
                 let newDict = Dictionary<obj,obj>()
                 for kv in o do newDict.Add(tryDeepCopyObj kv.Key, tryDeepCopyObj kv.Value)
                 newDict |> box
-            | o when FableJS.Dictionaries.isMap o -> 
+            | o when FableJS.Dictionaries.isDict o -> 
                 let o = o |> unbox<Dictionary<obj,obj>>
                 let newDict = Dictionary<obj,obj>()
                 for kv in o do newDict.Add(tryDeepCopyObj kv.Key, tryDeepCopyObj kv.Value)

--- a/src/DynamicObj/DynamicObj.fs
+++ b/src/DynamicObj/DynamicObj.fs
@@ -267,7 +267,7 @@ type DynamicObj() =
     ///
     /// The following cases are handled (in this precedence):
     ///
-    /// - Basic F# types (int, float, bool, string, char, byte, sbyte, int16, uint16, int32, uint32, int64, uint64, single, decimal)
+    /// - Basic F# types (bool, byte, sbyte, int16, uint16, int, uint, int64, uint64, nativeint, unativeint, float, float32, char, string, unit, decimal)
     ///
     /// - ResizeArrays and Dictionaries containing any combination of basic F# types
     ///
@@ -311,7 +311,7 @@ type DynamicObj() =
     ///
     /// The following cases are handled (in this precedence):
     ///
-    /// - Basic F# types (int, float, bool, string, char, byte, sbyte, int16, uint16, int32, uint32, int64, uint64, single, decimal)
+    /// - Basic F# types (bool, byte, sbyte, int16, uint16, int, uint, int64, uint64, nativeint, unativeint, float, float32, char, string, unit, decimal)
     ///
     /// - ResizeArrays and Dictionaries containing any combination of basic F# types
     ///
@@ -433,6 +433,10 @@ and CopyUtils =
 
             // we can do some more type checking in F# land
 
+            // ResizeArray typematches are all translated as `isArrayLike` in Fable JS/Py, so all these cases are the same in transpiled code.
+            // However this is fine, as we can transpile one single case (the `ResizeArray<DynamicObj>` case) that recursively applies `tryDeepCopyObj` on all items.
+            // That way, everything is fine in the untyped world, and we can keep the boxed types in F#.
+
             // ResizeArrays are mutable and we need to copy them. For primitives, we can do this easily.
             | :? ResizeArray<bool>       as r -> ResizeArray(r) |> box
             | :? ResizeArray<byte>       as r -> ResizeArray(r) |> box
@@ -450,8 +454,10 @@ and CopyUtils =
             | :? ResizeArray<char>       as r -> ResizeArray(r) |> box
             | :? ResizeArray<string>     as r -> ResizeArray(r) |> box
             | :? ResizeArray<unit>       as r -> ResizeArray(r) |> box
+            | :? ResizeArray<decimal>    as r -> ResizeArray(r) |> box
 
             // Dictionaries are mutable and we need to copy them. For primitives, we can do this easily, it is just a lot of work to write man
+            // Fable does simply not compile these typechecks, i guess because everything is an object/dictionary in JS/PY.
             | :? Dictionary<bool,bool>         as dict -> Dictionary<bool,bool>(dict) |> box
             | :? Dictionary<bool,byte>         as dict -> Dictionary<bool,byte>(dict) |> box
             | :? Dictionary<bool,sbyte>        as dict -> Dictionary<bool,sbyte>(dict) |> box
@@ -468,6 +474,7 @@ and CopyUtils =
             | :? Dictionary<bool,char>         as dict -> Dictionary<bool,char>(dict) |> box
             | :? Dictionary<bool,string>       as dict -> Dictionary<bool,string>(dict) |> box
             | :? Dictionary<bool,unit>         as dict -> Dictionary<bool,unit>(dict) |> box
+            | :? Dictionary<bool,decimal>      as dict -> Dictionary<bool,decimal>(dict) |> box
             
             | :? Dictionary<byte,bool>         as dict -> Dictionary<byte,bool>(dict) |> box
             | :? Dictionary<byte,byte>         as dict -> Dictionary<byte,byte>(dict) |> box
@@ -485,6 +492,7 @@ and CopyUtils =
             | :? Dictionary<byte,char>         as dict -> Dictionary<byte,char>(dict) |> box
             | :? Dictionary<byte,string>       as dict -> Dictionary<byte,string>(dict) |> box
             | :? Dictionary<byte,unit>         as dict -> Dictionary<byte,unit>(dict) |> box
+            | :? Dictionary<byte,decimal>      as dict -> Dictionary<byte,decimal>(dict) |> box
             
             | :? Dictionary<sbyte,bool>         as dict -> Dictionary<sbyte,bool>(dict) |> box
             | :? Dictionary<sbyte,byte>         as dict -> Dictionary<sbyte,byte>(dict) |> box
@@ -502,6 +510,7 @@ and CopyUtils =
             | :? Dictionary<sbyte,char>         as dict -> Dictionary<sbyte,char>(dict) |> box
             | :? Dictionary<sbyte,string>       as dict -> Dictionary<sbyte,string>(dict) |> box
             | :? Dictionary<sbyte,unit>         as dict -> Dictionary<sbyte,unit>(dict) |> box
+            | :? Dictionary<sbyte,decimal>      as dict -> Dictionary<sbyte,decimal>(dict) |> box
             
             | :? Dictionary<int16,bool>         as dict -> Dictionary<int16,bool>(dict) |> box
             | :? Dictionary<int16,byte>         as dict -> Dictionary<int16,byte>(dict) |> box
@@ -519,6 +528,7 @@ and CopyUtils =
             | :? Dictionary<int16,char>         as dict -> Dictionary<int16,char>(dict) |> box
             | :? Dictionary<int16,string>       as dict -> Dictionary<int16,string>(dict) |> box
             | :? Dictionary<int16,unit>         as dict -> Dictionary<int16,unit>(dict) |> box
+            | :? Dictionary<int16,decimal>      as dict -> Dictionary<int16,decimal>(dict) |> box
             
             | :? Dictionary<uint16,bool>         as dict -> Dictionary<uint16,bool>(dict) |> box
             | :? Dictionary<uint16,byte>         as dict -> Dictionary<uint16,byte>(dict) |> box
@@ -536,6 +546,7 @@ and CopyUtils =
             | :? Dictionary<uint16,char>         as dict -> Dictionary<uint16,char>(dict) |> box
             | :? Dictionary<uint16,string>       as dict -> Dictionary<uint16,string>(dict) |> box
             | :? Dictionary<uint16,unit>         as dict -> Dictionary<uint16,unit>(dict) |> box
+            | :? Dictionary<uint16,decimal>      as dict -> Dictionary<uint16,decimal>(dict) |> box
             
             | :? Dictionary<int,bool>         as dict -> Dictionary<int,bool>(dict) |> box
             | :? Dictionary<int,byte>         as dict -> Dictionary<int,byte>(dict) |> box
@@ -553,6 +564,7 @@ and CopyUtils =
             | :? Dictionary<int,char>         as dict -> Dictionary<int,char>(dict) |> box
             | :? Dictionary<int,string>       as dict -> Dictionary<int,string>(dict) |> box
             | :? Dictionary<int,unit>         as dict -> Dictionary<int,unit>(dict) |> box
+            | :? Dictionary<int,decimal>      as dict -> Dictionary<int,decimal>(dict) |> box
             
             | :? Dictionary<uint,bool>         as dict -> Dictionary<uint,bool>(dict) |> box
             | :? Dictionary<uint,byte>         as dict -> Dictionary<uint,byte>(dict) |> box
@@ -570,6 +582,7 @@ and CopyUtils =
             | :? Dictionary<uint,char>         as dict -> Dictionary<uint,char>(dict) |> box
             | :? Dictionary<uint,string>       as dict -> Dictionary<uint,string>(dict) |> box
             | :? Dictionary<uint,unit>         as dict -> Dictionary<uint,unit>(dict) |> box
+            | :? Dictionary<uint,decimal>      as dict -> Dictionary<uint,decimal>(dict) |> box
             
             | :? Dictionary<int64,bool>         as dict -> Dictionary<int64,bool>(dict) |> box
             | :? Dictionary<int64,byte>         as dict -> Dictionary<int64,byte>(dict) |> box
@@ -587,6 +600,7 @@ and CopyUtils =
             | :? Dictionary<int64,char>         as dict -> Dictionary<int64,char>(dict) |> box
             | :? Dictionary<int64,string>       as dict -> Dictionary<int64,string>(dict) |> box
             | :? Dictionary<int64,unit>         as dict -> Dictionary<int64,unit>(dict) |> box
+            | :? Dictionary<int64,decimal>      as dict -> Dictionary<int64,decimal>(dict) |> box
             
             | :? Dictionary<uint64,bool>         as dict -> Dictionary<uint64,bool>(dict) |> box
             | :? Dictionary<uint64,byte>         as dict -> Dictionary<uint64,byte>(dict) |> box
@@ -604,6 +618,7 @@ and CopyUtils =
             | :? Dictionary<uint64,char>         as dict -> Dictionary<uint64,char>(dict) |> box
             | :? Dictionary<uint64,string>       as dict -> Dictionary<uint64,string>(dict) |> box
             | :? Dictionary<uint64,unit>         as dict -> Dictionary<uint64,unit>(dict) |> box
+            | :? Dictionary<uint64,decimal>      as dict -> Dictionary<uint64,decimal>(dict) |> box
             
             | :? Dictionary<nativeint,bool>         as dict -> Dictionary<nativeint,bool>(dict) |> box
             | :? Dictionary<nativeint,byte>         as dict -> Dictionary<nativeint,byte>(dict) |> box
@@ -621,6 +636,7 @@ and CopyUtils =
             | :? Dictionary<nativeint,char>         as dict -> Dictionary<nativeint,char>(dict) |> box
             | :? Dictionary<nativeint,string>       as dict -> Dictionary<nativeint,string>(dict) |> box
             | :? Dictionary<nativeint,unit>         as dict -> Dictionary<nativeint,unit>(dict) |> box
+            | :? Dictionary<nativeint,decimal>      as dict -> Dictionary<nativeint,decimal>(dict) |> box
             
             | :? Dictionary<unativeint,bool>         as dict -> Dictionary<unativeint,bool>(dict) |> box
             | :? Dictionary<unativeint,byte>         as dict -> Dictionary<unativeint,byte>(dict) |> box
@@ -638,6 +654,7 @@ and CopyUtils =
             | :? Dictionary<unativeint,char>         as dict -> Dictionary<unativeint,char>(dict) |> box
             | :? Dictionary<unativeint,string>       as dict -> Dictionary<unativeint,string>(dict) |> box
             | :? Dictionary<unativeint,unit>         as dict -> Dictionary<unativeint,unit>(dict) |> box
+            | :? Dictionary<unativeint,decimal>      as dict -> Dictionary<unativeint,decimal>(dict) |> box
 
             | :? Dictionary<float,bool>         as dict -> Dictionary<float,bool>(dict) |> box
             | :? Dictionary<float,byte>         as dict -> Dictionary<float,byte>(dict) |> box
@@ -655,6 +672,7 @@ and CopyUtils =
             | :? Dictionary<float,char>         as dict -> Dictionary<float,char>(dict) |> box
             | :? Dictionary<float,string>       as dict -> Dictionary<float,string>(dict) |> box
             | :? Dictionary<float,unit>         as dict -> Dictionary<float,unit>(dict) |> box
+            | :? Dictionary<float,decimal>      as dict -> Dictionary<float,decimal>(dict) |> box
             
             | :? Dictionary<float32,bool>         as dict -> Dictionary<float32,bool>(dict) |> box
             | :? Dictionary<float32,byte>         as dict -> Dictionary<float32,byte>(dict) |> box
@@ -672,6 +690,7 @@ and CopyUtils =
             | :? Dictionary<float32,char>         as dict -> Dictionary<float32,char>(dict) |> box
             | :? Dictionary<float32,string>       as dict -> Dictionary<float32,string>(dict) |> box
             | :? Dictionary<float32,unit>         as dict -> Dictionary<float32,unit>(dict) |> box
+            | :? Dictionary<float32,decimal>      as dict -> Dictionary<float32,decimal>(dict) |> box
             
             | :? Dictionary<char,bool>         as dict -> Dictionary<char,bool>(dict) |> box
             | :? Dictionary<char,byte>         as dict -> Dictionary<char,byte>(dict) |> box
@@ -689,6 +708,7 @@ and CopyUtils =
             | :? Dictionary<char,char>         as dict -> Dictionary<char,char>(dict) |> box
             | :? Dictionary<char,string>       as dict -> Dictionary<char,string>(dict) |> box
             | :? Dictionary<char,unit>         as dict -> Dictionary<char,unit>(dict) |> box
+            | :? Dictionary<char,decimal>      as dict -> Dictionary<char,decimal>(dict) |> box
             
             | :? Dictionary<string,bool>         as dict -> Dictionary<string,bool>(dict) |> box
             | :? Dictionary<string,byte>         as dict -> Dictionary<string,byte>(dict) |> box
@@ -706,6 +726,7 @@ and CopyUtils =
             | :? Dictionary<string,char>         as dict -> Dictionary<string,char>(dict) |> box
             | :? Dictionary<string,string>       as dict -> Dictionary<string,string>(dict) |> box
             | :? Dictionary<string,unit>         as dict -> Dictionary<string,unit>(dict) |> box
+            | :? Dictionary<string,decimal>      as dict -> Dictionary<string,decimal>(dict) |> box
             
             | :? Dictionary<unit,bool>         as dict -> Dictionary<unit,bool>(dict) |> box
             | :? Dictionary<unit,byte>         as dict -> Dictionary<unit,byte>(dict) |> box
@@ -723,6 +744,25 @@ and CopyUtils =
             | :? Dictionary<unit,char>         as dict -> Dictionary<unit,char>(dict) |> box
             | :? Dictionary<unit,string>       as dict -> Dictionary<unit,string>(dict) |> box
             | :? Dictionary<unit,unit>         as dict -> Dictionary<unit,unit>(dict) |> box
+            | :? Dictionary<unit,decimal>      as dict -> Dictionary<unit,decimal>(dict) |> box
+
+            | :? Dictionary<decimal,bool>         as dict -> Dictionary<decimal,bool>(dict) |> box
+            | :? Dictionary<decimal,byte>         as dict -> Dictionary<decimal,byte>(dict) |> box
+            | :? Dictionary<decimal,sbyte>        as dict -> Dictionary<decimal,sbyte>(dict) |> box
+            | :? Dictionary<decimal,int16>        as dict -> Dictionary<decimal,int16>(dict) |> box
+            | :? Dictionary<decimal,uint16>       as dict -> Dictionary<decimal,uint16>(dict) |> box
+            | :? Dictionary<decimal,int>          as dict -> Dictionary<decimal,int>(dict) |> box
+            | :? Dictionary<decimal,uint>         as dict -> Dictionary<decimal,uint>(dict) |> box
+            | :? Dictionary<decimal,int64>        as dict -> Dictionary<decimal,int64>(dict) |> box
+            | :? Dictionary<decimal,uint64>       as dict -> Dictionary<decimal,uint64>(dict) |> box
+            | :? Dictionary<decimal,nativeint>    as dict -> Dictionary<decimal,nativeint>(dict) |> box
+            | :? Dictionary<decimal,unativeint>   as dict -> Dictionary<decimal,unativeint>(dict) |> box
+            | :? Dictionary<decimal,float>        as dict -> Dictionary<decimal,float>(dict) |> box
+            | :? Dictionary<decimal,float32>      as dict -> Dictionary<decimal,float32>(dict) |> box
+            | :? Dictionary<decimal,char>         as dict -> Dictionary<decimal,char>(dict) |> box
+            | :? Dictionary<decimal,string>       as dict -> Dictionary<decimal,string>(dict) |> box
+            | :? Dictionary<decimal,unit>         as dict -> Dictionary<decimal,unit>(dict) |> box
+            | :? Dictionary<decimal,decimal>      as dict -> Dictionary<decimal,decimal>(dict) |> box
 
             // same for dictionaries containing DynamicObj as value
             | :? Dictionary<bool,DynamicObj>         as dict -> 
@@ -859,14 +899,39 @@ and CopyUtils =
                 let newDict = Dictionary<DynamicObj,DynamicObj>()
                 for kv in dict do newDict.Add(tryDeepCopyObj kv.Key :?> DynamicObj, tryDeepCopyObj kv.Value :?> DynamicObj)
                 newDict |> box
+            #endif
 
+            // native fallbacks for matching Map/dict, see https://github.com/CSBiology/DynamicObj/issues/47
+
+            #if FABLE_COMPILER_JAVASCRIPT || FABLE_COMPILER_TYPESCRIPT
+            | o when FableJS.Dictionaries.isMap o -> 
+                let o = o |> unbox<Dictionary<obj,obj>>
+                let newDict = Dictionary<obj,obj>()
+                for kv in o do newDict.Add(tryDeepCopyObj kv.Key, tryDeepCopyObj kv.Value)
+                newDict |> box
+            | o when FableJS.Dictionaries.isMap o -> 
+                let o = o |> unbox<Dictionary<obj,obj>>
+                let newDict = Dictionary<obj,obj>()
+                for kv in o do newDict.Add(tryDeepCopyObj kv.Key, tryDeepCopyObj kv.Value)
+                newDict |> box
+            #endif
+            #if FABLE_COMPILER_PYTHON
+            // https://github.com/fable-compiler/Fable/issues/3972
+            | o when FablePy.Dictionaries.isDict o ->
+                let o = o |> unbox<Dictionary<obj,obj>>
+                let newDict = Dictionary<obj,obj>()
+                for kv in o do newDict.Add(tryDeepCopyObj kv.Key, tryDeepCopyObj kv.Value)
+                newDict |> box
             #endif
 
             // These collections of DynamicObj can be cloned recursively
             | :? ResizeArray<DynamicObj> as dyns ->
                 box (ResizeArray([for dyn in dyns -> tryDeepCopyObj dyn :?> DynamicObj]))
+            #if !FABLE_COMPILER
+            // this gets compiled to isArrayLike just the same as ResizeArray, but generates a slightly different result handling, so we only transpile the above.
             | :? array<DynamicObj> as dyns ->
                 box [|for dyn in dyns -> tryDeepCopyObj dyn :?> DynamicObj|]
+            #endif
             | :? list<DynamicObj> as dyns ->
                 box [for dyn in dyns -> tryDeepCopyObj dyn :?> DynamicObj]
 

--- a/src/DynamicObj/DynamicObj.fs
+++ b/src/DynamicObj/DynamicObj.fs
@@ -413,8 +413,10 @@ and CopyUtils =
             | :? uint
             | :? int64
             | :? uint64
+            #if !FABLE_COMPILER
             | :? nativeint
             | :? unativeint
+            #endif
             | :? float
             | :? float32
             | :? char
@@ -426,6 +428,10 @@ and CopyUtils =
             // https://github.com/fable-compiler/Fable/issues/3971
             | :? decimal -> o
             #endif
+
+            #if !FABLE_COMPILER
+
+            // we can do some more type checking in F# land
 
             // ResizeArrays are mutable and we need to copy them. For primitives, we can do this easily.
             | :? ResizeArray<bool>       as r -> ResizeArray(r) |> box
@@ -632,7 +638,7 @@ and CopyUtils =
             | :? Dictionary<unativeint,char>         as dict -> Dictionary<unativeint,char>(dict) |> box
             | :? Dictionary<unativeint,string>       as dict -> Dictionary<unativeint,string>(dict) |> box
             | :? Dictionary<unativeint,unit>         as dict -> Dictionary<unativeint,unit>(dict) |> box
-            
+
             | :? Dictionary<float,bool>         as dict -> Dictionary<float,bool>(dict) |> box
             | :? Dictionary<float,byte>         as dict -> Dictionary<float,byte>(dict) |> box
             | :? Dictionary<float,sbyte>        as dict -> Dictionary<float,sbyte>(dict) |> box
@@ -854,6 +860,8 @@ and CopyUtils =
                 for kv in dict do newDict.Add(tryDeepCopyObj kv.Key :?> DynamicObj, tryDeepCopyObj kv.Value :?> DynamicObj)
                 newDict |> box
 
+            #endif
+
             // These collections of DynamicObj can be cloned recursively
             | :? ResizeArray<DynamicObj> as dyns ->
                 box (ResizeArray([for dyn in dyns -> tryDeepCopyObj dyn :?> DynamicObj]))
@@ -878,7 +886,7 @@ and CopyUtils =
                 let newDyn = DynamicObj()
                 // might want to keep instance props as dynamic props on copy
                 for kv in (dyn.GetProperties(true)) do
-                    newDyn.SetProperty(kv.Key, tryDeepCopyObj kv.Value :?> DynamicObj)
+                    newDyn.SetProperty(kv.Key, tryDeepCopyObj kv.Value)
                 box newDyn
             | _ -> o
 

--- a/src/DynamicObj/FableJS.fs
+++ b/src/DynamicObj/FableJS.fs
@@ -168,4 +168,11 @@ module FableJS =
         let cloneICloneable (o:obj) : obj =
             jsNative
 
+    module Dictionaries =
+        [<Emit("""$0 instanceof Map""")>]
+        let isMap (o:obj) : bool =
+            jsNative
+        [<Emit("""$0 instanceof Dictionary""")>]
+        let isDict (o:obj) : bool =
+            jsNative
 #endif

--- a/src/DynamicObj/FablePy.fs
+++ b/src/DynamicObj/FablePy.fs
@@ -220,4 +220,10 @@ module FablePy =
         [<Emit("""$0.System_ICloneable_Clone()""")>]
         let cloneICloneable (o:obj) : obj =
             nativeOnly
+
+    module Dictionaries =
+        [<Emit("""isinstance($0, dict)""")>]
+        let isDict (o:obj) : bool =
+            nativeOnly
+
 #endif

--- a/src/DynamicObj/Playground.fsx
+++ b/src/DynamicObj/Playground.fsx
@@ -13,33 +13,10 @@
 open Fable.Pyxpecto
 open DynamicObj
 
-let constructDeepCopiedClone<'T> (props: seq<string*obj>) =
-    let original = DynamicObj()
-    props
-    |> Seq.iter (fun (propertyName, propertyValue) -> original.SetProperty(propertyName, propertyValue))
-    let clone : 'T = original.DeepCopyProperties() |> unbox<'T>
-    original, clone 
+let r1 = ResizeArray([1; 2])
+let r2 = ResizeArray([1; 2])
+let r3 = r1
 
-let originalProps = [ 
-    "int", box 1
-    "float", box 1.0
-    "bool", box true
-    "string", box "hello"
-    "char", box 'a'
-    "byte", box (byte 1)
-    "sbyte", box (sbyte -1)
-    "int16", box (int16 -1)
-    "uint16", box (uint16 1)
-    "int32", box (int32 -1)
-    "uint32", box (uint32 1u)
-    "int64", box (int64 -1L)
-    "uint64", box (uint64 1UL)
-    "single", box (single 1.0f)
-    "decimal", box (decimal 1M) 
-]
-let original = DynamicObj()
-
-originalProps
-|> Seq.iter (fun (propertyName, propertyValue) -> original.SetProperty(propertyName, propertyValue))
-
-let clone = original.DeepCopyProperties()
+printfn "%A" (LanguagePrimitives.PhysicalEquality r1 r2)
+printfn "%A" (LanguagePrimitives.PhysicalEquality r2 r2)
+printfn "%A" (LanguagePrimitives.PhysicalEquality r3 r1)

--- a/src/DynamicObj/Playground.fsx
+++ b/src/DynamicObj/Playground.fsx
@@ -13,18 +13,33 @@
 open Fable.Pyxpecto
 open DynamicObj
 
-type T(dyn:string, stat:string) as this=
-    inherit DynamicObj()
+let constructDeepCopiedClone<'T> (props: seq<string*obj>) =
+    let original = DynamicObj()
+    props
+    |> Seq.iter (fun (propertyName, propertyValue) -> original.SetProperty(propertyName, propertyValue))
+    let clone : 'T = original.DeepCopyProperties() |> unbox<'T>
+    original, clone 
 
-    do 
-        this.SetProperty("Dyn", dyn)
+let originalProps = [ 
+    "int", box 1
+    "float", box 1.0
+    "bool", box true
+    "string", box "hello"
+    "char", box 'a'
+    "byte", box (byte 1)
+    "sbyte", box (sbyte -1)
+    "int16", box (int16 -1)
+    "uint16", box (uint16 1)
+    "int32", box (int32 -1)
+    "uint32", box (uint32 1u)
+    "int64", box (int64 -1L)
+    "uint64", box (uint64 1UL)
+    "single", box (single 1.0f)
+    "decimal", box (decimal 1M) 
+]
+let original = DynamicObj()
 
-    member this.Stat = stat
+originalProps
+|> Seq.iter (fun (propertyName, propertyValue) -> original.SetProperty(propertyName, propertyValue))
 
-let first = T("dyn1", "stat1")
-let second = T("dyn2", "stat2")
-
-let _ = second.ShallowCopyDynamicPropertiesTo(first)
-
-first |> DynObj.print
-second |> DynObj.print
+let clone = original.DeepCopyProperties()

--- a/tests/CSharpTests/CSharpTests.csproj
+++ b/tests/CSharpTests/CSharpTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/DynamicObject.Tests/CopyUtils.tryDeepCopyObj/Dictionaries.fs
+++ b/tests/DynamicObject.Tests/CopyUtils.tryDeepCopyObj/Dictionaries.fs
@@ -1,2 +1,22 @@
 ﻿module DeepCopyDictionaries
 
+open System
+open Fable.Pyxpecto
+open DynamicObj
+open Fable.Core
+open TestUtils
+open System.Collections.Generic
+
+let tests_DeepCopyDictionaries = testList "Dictionaries" [
+// there are hundreds of potential test cases here for each type combination
+    testCase "string, string" <| fun _ -> 
+        let d = new Dictionary<string, string>()
+        d.Add("k1", "v1")
+        d.Add("k2", "v2")
+        let original, copy = constructDeepCopiedObj d
+        Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+        Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+        d.["k1"] <- "mutated"
+        Expect.sequenceEqual original (dict [ "k1", "mutated"; "k2", "v2" ]) "Original schould have been mutated"
+        Expect.sequenceEqual copy (dict [ "k1", "v1"; "k2", "v2" ]) "Clone should not be affected by original mutation"
+]

--- a/tests/DynamicObject.Tests/CopyUtils.tryDeepCopyObj/Dictionaries.fs
+++ b/tests/DynamicObject.Tests/CopyUtils.tryDeepCopyObj/Dictionaries.fs
@@ -1,0 +1,2 @@
+﻿module DeepCopyDictionaries
+

--- a/tests/DynamicObject.Tests/CopyUtils.tryDeepCopyObj/Dictionaries.fs
+++ b/tests/DynamicObject.Tests/CopyUtils.tryDeepCopyObj/Dictionaries.fs
@@ -9,14 +9,374 @@ open System.Collections.Generic
 
 let tests_DeepCopyDictionaries = testList "Dictionaries" [
 // there are hundreds of potential test cases here for each type combination
-    testCase "string, string" <| fun _ -> 
-        let d = new Dictionary<string, string>()
-        d.Add("k1", "v1")
-        d.Add("k2", "v2")
-        let original, copy = constructDeepCopiedObj d
-        Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
-        Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
-        d.["k1"] <- "mutated"
-        Expect.sequenceEqual original (dict [ "k1", "mutated"; "k2", "v2" ]) "Original schould have been mutated"
-        Expect.sequenceEqual copy (dict [ "k1", "v1"; "k2", "v2" ]) "Clone should not be affected by original mutation"
+    testList "bool keys" [
+        testCase "bool values" <| fun _ ->
+            let d = new Dictionary<bool, bool>()
+            d.Add(true, true)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[true] <- false
+            Expect.sequenceEqual original (dict [true, false]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [true, true]) "Clone should not be affected by original mutation"
+        testCase "byte values" <| fun _ ->       
+            let d = new Dictionary<bool, byte>()
+            d.Add(true, 1uy)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[true] <- 2uy
+            Expect.sequenceEqual original (dict [true, 2uy]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [true, 1uy]) "Clone should not be affected by original mutation"
+        testCase "sbyte values" <| fun _ ->      
+            let d = new Dictionary<bool, sbyte>()
+            d.Add(true, 1y)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[true] <- 2y
+            Expect.sequenceEqual original (dict [true, 2y]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [true, 1y]) "Clone should not be affected by original mutation"
+        testCase "int16 values" <| fun _ ->      
+            let d = new Dictionary<bool, int16>()
+            d.Add(true, 1s)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[true] <- 2s
+            Expect.sequenceEqual original (dict [true, 2s]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [true, 1s]) "Clone should not be affected by original mutation"
+        testCase "uint16 values" <| fun _ ->     
+            let d = new Dictionary<bool, uint16>()
+            d.Add(true, 1us)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[true] <- 2us
+            Expect.sequenceEqual original (dict [true, 2us]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [true, 1us]) "Clone should not be affected by original mutation"
+        testCase "int values" <| fun _ ->        
+            let d = new Dictionary<bool, int>()
+            d.Add(true, 1)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[true] <- 2
+            Expect.sequenceEqual original (dict [true, 2]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [true, 1]) "Clone should not be affected by original mutation"
+        testCase "uint values" <| fun _ ->       
+            let d = new Dictionary<bool, uint>()
+            d.Add(true, 1u)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[true] <- 2u
+            Expect.sequenceEqual original (dict [true, 2u]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [true, 1u]) "Clone should not be affected by original mutation"
+        testCase "int64 values" <| fun _ ->      
+            let d = new Dictionary<bool, int64>()
+            d.Add(true, 1L)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[true] <- 2L
+            Expect.sequenceEqual original (dict [true, 2L]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [true, 1L]) "Clone should not be affected by original mutation"
+        testCase "uint64 values" <| fun _ ->     
+            let d = new Dictionary<bool, uint64>()
+            d.Add(true, 1uL)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[true] <- 2uL
+            Expect.sequenceEqual original (dict [true, 2uL]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [true, 1uL]) "Clone should not be affected by original mutation"
+        testCase "float values" <| fun _ ->      
+            let d = new Dictionary<bool, float>()
+            d.Add(true, 1.0)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[true] <- 2.0
+            Expect.sequenceEqual original (dict [true, 2.0]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [true, 1.0]) "Clone should not be affected by original mutation"
+        testCase "float32 values" <| fun _ ->    
+            let d = new Dictionary<bool, float32>()
+            d.Add(true, 1.0f)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[true] <- 2.0f
+            Expect.sequenceEqual original (dict [true, 2.0f]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [true, 1.0f]) "Clone should not be affected by original mutation"
+        testCase "char values" <| fun _ ->       
+            let d = new Dictionary<bool, char>()
+            d.Add(true, 'A')
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[true] <- 'B'
+            Expect.sequenceEqual original (dict [true, 'B']) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [true, 'A']) "Clone should not be affected by original mutation"
+        testCase "string values" <| fun _ ->     
+            let d = new Dictionary<bool, string>()
+            d.Add(true, "k1")
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[true] <- "k2"
+            Expect.sequenceEqual original (dict [true, "k2"]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [true, "k1"]) "Clone should not be affected by original mutation"
+        testCase "unit values" <| fun _ ->       
+            let d = new Dictionary<bool, unit>()
+            d.Add(true, ())
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.Add(false,())
+            Expect.sequenceEqual original (dict [true, (); false, ()]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [true, ()]) "Clone should not be affected by original mutation"
+        #if !FABLE_COMPILER_PYTHON
+        testCase "decimal values" <| fun _ ->    
+            let d = new Dictionary<bool, decimal>()
+            d.Add(true, 1.0M)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[true] <- 2.0M
+            Expect.sequenceEqual original (dict [true, 2.0M]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [true, 1.0M]) "Clone should not be affected by original mutation"
+        #endif
+        #if !FABLE_COMPILER
+        testCase "nativeint values" <| fun _ ->  
+            let d = new Dictionary<bool, nativeint>()
+            d.Add(true, System.IntPtr(1))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[true] <- System.IntPtr(2)
+            Expect.sequenceEqual original (dict [true, System.IntPtr(2)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [true, System.IntPtr(1)]) "Clone should not be affected by original mutation"
+        testCase "unativeint values" <| fun _ -> 
+            let d = new Dictionary<bool, unativeint>()
+            d.Add(true, System.UIntPtr(1u))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[true] <- System.UIntPtr(2u)
+            Expect.sequenceEqual original (dict [true, System.UIntPtr(2u)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [true, System.UIntPtr(1u)]) "Clone should not be affected by original mutation"
+        #endif
+    ]
+    testList "byte keys" [
+        testCase "bool values" <| fun _ ->
+            let d = new Dictionary<byte, bool>()
+            d.Add(1uy, true)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uy] <- false
+            Expect.sequenceEqual original (dict [1uy, false]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uy, true]) "Clone should not be affected by original mutation"
+        testCase "byte values" <| fun _ ->       
+            let d = new Dictionary<byte, byte>()
+            d.Add(1uy, 1uy)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uy] <- 2uy
+            Expect.sequenceEqual original (dict [1uy, 2uy]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uy, 1uy]) "Clone should not be affected by original mutation"
+        testCase "sbyte values" <| fun _ ->      
+            let d = new Dictionary<byte, sbyte>()
+            d.Add(1uy, 1y)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uy] <- 2y
+            Expect.sequenceEqual original (dict [1uy, 2y]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uy, 1y]) "Clone should not be affected by original mutation"
+        testCase "int16 values" <| fun _ ->      
+            let d = new Dictionary<byte, int16>()
+            d.Add(1uy, 1s)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uy] <- 2s
+            Expect.sequenceEqual original (dict [1uy, 2s]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uy, 1s]) "Clone should not be affected by original mutation"
+        testCase "uint16 values" <| fun _ ->     
+            let d = new Dictionary<byte, uint16>()
+            d.Add(1uy, 1us)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uy] <- 2us
+            Expect.sequenceEqual original (dict [1uy, 2us]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uy, 1us]) "Clone should not be affected by original mutation"
+        testCase "int values" <| fun _ ->        
+            let d = new Dictionary<byte, int>()
+            d.Add(1uy, 1)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uy] <- 2
+            Expect.sequenceEqual original (dict [1uy, 2]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uy, 1]) "Clone should not be affected by original mutation"
+        testCase "uint values" <| fun _ ->       
+            let d = new Dictionary<byte, uint>()
+            d.Add(1uy, 1u)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uy] <- 2u
+            Expect.sequenceEqual original (dict [1uy, 2u]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uy, 1u]) "Clone should not be affected by original mutation"
+        testCase "int64 values" <| fun _ ->      
+            let d = new Dictionary<byte, int64>()
+            d.Add(1uy, 1L)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uy] <- 2L
+            Expect.sequenceEqual original (dict [1uy, 2L]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uy, 1L]) "Clone should not be affected by original mutation"
+        testCase "uint64 values" <| fun _ ->     
+            let d = new Dictionary<byte, uint64>()
+            d.Add(1uy, 1uL)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uy] <- 2uL
+            Expect.sequenceEqual original (dict [1uy, 2uL]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uy, 1uL]) "Clone should not be affected by original mutation"
+        testCase "float values" <| fun _ ->      
+            let d = new Dictionary<byte, float>()
+            d.Add(1uy, 1.0)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uy] <- 2.0
+            Expect.sequenceEqual original (dict [1uy, 2.0]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uy, 1.0]) "Clone should not be affected by original mutation"
+        testCase "float32 values" <| fun _ ->    
+            let d = new Dictionary<byte, float32>()
+            d.Add(1uy, 1.0f)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uy] <- 2.0f
+            Expect.sequenceEqual original (dict [1uy, 2.0f]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uy, 1.0f]) "Clone should not be affected by original mutation"
+        testCase "char values" <| fun _ ->       
+            let d = new Dictionary<byte, char>()
+            d.Add(1uy, 'A')
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uy] <- 'B'
+            Expect.sequenceEqual original (dict [1uy, 'B']) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uy, 'A']) "Clone should not be affected by original mutation"
+        testCase "string values" <| fun _ ->     
+            let d = new Dictionary<byte, string>()
+            d.Add(1uy, "k1")
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uy] <- "k2"
+            Expect.sequenceEqual original (dict [1uy, "k2"]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uy, "k1"]) "Clone should not be affected by original mutation"
+        testCase "unit values" <| fun _ ->       
+            let d = new Dictionary<byte, unit>()
+            d.Add(1uy, ())
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.Add(2uy,())
+            Expect.sequenceEqual original (dict [1uy, (); 2uy, ()]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uy, ()]) "Clone should not be affected by original mutation"
+        #if !FABLE_COMPILER_PYTHON
+        testCase "decimal values" <| fun _ ->    
+            let d = new Dictionary<byte, decimal>()
+            d.Add(1uy, 1.0M)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uy] <- 2.0M
+            Expect.sequenceEqual original (dict [1uy, 2.0M]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uy, 1.0M]) "Clone should not be affected by original mutation"
+        #endif
+        #if !FABLE_COMPILER
+        testCase "nativeint values" <| fun _ ->  
+            let d = new Dictionary<byte, nativeint>()
+            d.Add(1uy, System.IntPtr(1))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uy] <- System.IntPtr(2)
+            Expect.sequenceEqual original (dict [1uy, System.IntPtr(2)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uy, System.IntPtr(1)]) "Clone should not be affected by original mutation"
+        testCase "unativeint values" <| fun _ -> 
+            let d = new Dictionary<byte, unativeint>()
+            d.Add(1uy, System.UIntPtr(1u))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uy] <- System.UIntPtr(2u)
+            Expect.sequenceEqual original (dict [1uy, System.UIntPtr(2u)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uy, System.UIntPtr(1u)]) "Clone should not be affected by original mutation"
+        #endif
+    ]
+    //testList "byte keys" [
+
+    //]
+    //testList "sbyte keys" [
+
+    //]
+    //testList "int16 keys" [
+
+    //]
+    //testList "uint16 keys" [
+
+    //]
+    //testList "int keys" [
+
+    //]
+    //testList "uint keys" [
+
+    //]
+    //testList "int64 keys" [
+
+    //]
+    //testList "uint64 keys" [
+
+    //]
+    //testList "float keys" [
+
+    //]
+    //testList "float32 keys" [
+
+    //]
+    //testList "char keys" [
+
+    //]
+    //testList "string keys" [
+
+    //]
+    //testList "unit keys" [
+
+    //]
+    #if !FABLE_COMPILER_PYTHON
+    //testList "decimal keys" [
+
+    //]
+    #endif
+    #if !FABLE_COMPILER
+    //testList "nativeint keys" [
+
+    //]
+    //testList "unativeint keys" [
+
+    //]
+    #endif
 ]

--- a/tests/DynamicObject.Tests/CopyUtils.tryDeepCopyObj/Dictionaries.fs
+++ b/tests/DynamicObject.Tests/CopyUtils.tryDeepCopyObj/Dictionaries.fs
@@ -327,56 +327,2237 @@ let tests_DeepCopyDictionaries = testList "Dictionaries" [
             Expect.sequenceEqual copy (dict [1uy, System.UIntPtr(1u)]) "Clone should not be affected by original mutation"
         #endif
     ]
-    //testList "byte keys" [
-
-    //]
-    //testList "sbyte keys" [
-
-    //]
-    //testList "int16 keys" [
-
-    //]
-    //testList "uint16 keys" [
-
-    //]
-    //testList "int keys" [
-
-    //]
-    //testList "uint keys" [
-
-    //]
-    //testList "int64 keys" [
-
-    //]
-    //testList "uint64 keys" [
-
-    //]
-    //testList "float keys" [
-
-    //]
-    //testList "float32 keys" [
-
-    //]
-    //testList "char keys" [
-
-    //]
-    //testList "string keys" [
-
-    //]
+    testList "sbyte keys" [
+        testCase "bool values" <| fun _ ->
+            let d = new Dictionary<sbyte, bool>()
+            d.Add(1y, true)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1y] <- false
+            Expect.sequenceEqual original (dict [1y, false]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1y, true]) "Clone should not be affected by original mutation"
+        testCase "byte values" <| fun _ ->       
+            let d = new Dictionary<sbyte, byte>()
+            d.Add(1y, 1uy)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1y] <- 2uy
+            Expect.sequenceEqual original (dict [1y, 2uy]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1y, 1uy]) "Clone should not be affected by original mutation"
+        testCase "sbyte values" <| fun _ ->      
+            let d = new Dictionary<sbyte, sbyte>()
+            d.Add(1y, 1y)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1y] <- 2y
+            Expect.sequenceEqual original (dict [1y, 2y]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1y, 1y]) "Clone should not be affected by original mutation"
+        testCase "int16 values" <| fun _ ->      
+            let d = new Dictionary<sbyte, int16>()
+            d.Add(1y, 1s)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1y] <- 2s
+            Expect.sequenceEqual original (dict [1y, 2s]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1y, 1s]) "Clone should not be affected by original mutation"
+        testCase "uint16 values" <| fun _ ->     
+            let d = new Dictionary<sbyte, uint16>()
+            d.Add(1y, 1us)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1y] <- 2us
+            Expect.sequenceEqual original (dict [1y, 2us]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1y, 1us]) "Clone should not be affected by original mutation"
+        testCase "int values" <| fun _ ->        
+            let d = new Dictionary<sbyte, int>()
+            d.Add(1y, 1)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1y] <- 2
+            Expect.sequenceEqual original (dict [1y, 2]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1y, 1]) "Clone should not be affected by original mutation"
+        testCase "uint values" <| fun _ ->       
+            let d = new Dictionary<sbyte, uint>()
+            d.Add(1y, 1u)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1y] <- 2u
+            Expect.sequenceEqual original (dict [1y, 2u]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1y, 1u]) "Clone should not be affected by original mutation"
+        testCase "int64 values" <| fun _ ->      
+            let d = new Dictionary<sbyte, int64>()
+            d.Add(1y, 1L)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1y] <- 2L
+            Expect.sequenceEqual original (dict [1y, 2L]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1y, 1L]) "Clone should not be affected by original mutation"
+        testCase "uint64 values" <| fun _ ->     
+            let d = new Dictionary<sbyte, uint64>()
+            d.Add(1y, 1uL)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1y] <- 2uL
+            Expect.sequenceEqual original (dict [1y, 2uL]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1y, 1uL]) "Clone should not be affected by original mutation"
+        testCase "float values" <| fun _ ->      
+            let d = new Dictionary<sbyte, float>()
+            d.Add(1y, 1.0)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1y] <- 2.0
+            Expect.sequenceEqual original (dict [1y, 2.0]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1y, 1.0]) "Clone should not be affected by original mutation"
+        testCase "float32 values" <| fun _ ->    
+            let d = new Dictionary<sbyte, float32>()
+            d.Add(1y, 1.0f)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1y] <- 2.0f
+            Expect.sequenceEqual original (dict [1y, 2.0f]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1y, 1.0f]) "Clone should not be affected by original mutation"
+        testCase "char values" <| fun _ ->       
+            let d = new Dictionary<sbyte, char>()
+            d.Add(1y, 'A')
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1y] <- 'B'
+            Expect.sequenceEqual original (dict [1y, 'B']) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1y, 'A']) "Clone should not be affected by original mutation"
+        testCase "string values" <| fun _ ->     
+            let d = new Dictionary<sbyte, string>()
+            d.Add(1y, "k1")
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1y] <- "k2"
+            Expect.sequenceEqual original (dict [1y, "k2"]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1y, "k1"]) "Clone should not be affected by original mutation"
+        testCase "unit values" <| fun _ ->       
+            let d = new Dictionary<sbyte, unit>()
+            d.Add(1y, ())
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.Add(2y,())
+            Expect.sequenceEqual original (dict [1y, (); 2y, ()]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1y, ()]) "Clone should not be affected by original mutation"
+        #if !FABLE_COMPILER_PYTHON
+        testCase "decimal values" <| fun _ ->    
+            let d = new Dictionary<sbyte, decimal>()
+            d.Add(1y, 1.0M)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1y] <- 2.0M
+            Expect.sequenceEqual original (dict [1y, 2.0M]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1y, 1.0M]) "Clone should not be affected by original mutation"
+        #endif
+        #if !FABLE_COMPILER
+        testCase "nativeint values" <| fun _ ->  
+            let d = new Dictionary<sbyte, nativeint>()
+            d.Add(1y, System.IntPtr(1))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1y] <- System.IntPtr(2)
+            Expect.sequenceEqual original (dict [1y, System.IntPtr(2)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1y, System.IntPtr(1)]) "Clone should not be affected by original mutation"
+        testCase "unativeint values" <| fun _ -> 
+            let d = new Dictionary<sbyte, unativeint>()
+            d.Add(1y, System.UIntPtr(1u))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1y] <- System.UIntPtr(2u)
+            Expect.sequenceEqual original (dict [1y, System.UIntPtr(2u)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1y, System.UIntPtr(1u)]) "Clone should not be affected by original mutation"
+        #endif
+    ]
+    testList "int16 keys" [
+        testCase "bool values" <| fun _ ->
+            let d = new Dictionary<int16, bool>()
+            d.Add(1s, true)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1s] <- false
+            Expect.sequenceEqual original (dict [1s, false]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1s, true]) "Clone should not be affected by original mutation"
+        testCase "byte values" <| fun _ ->       
+            let d = new Dictionary<int16, byte>()
+            d.Add(1s, 1uy)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1s] <- 2uy
+            Expect.sequenceEqual original (dict [1s, 2uy]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1s, 1uy]) "Clone should not be affected by original mutation"
+        testCase "sbyte values" <| fun _ ->      
+            let d = new Dictionary<int16, sbyte>()
+            d.Add(1s, 1y)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1s] <- 2y
+            Expect.sequenceEqual original (dict [1s, 2y]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1s, 1y]) "Clone should not be affected by original mutation"
+        testCase "int16 values" <| fun _ ->      
+            let d = new Dictionary<int16, int16>()
+            d.Add(1s, 1s)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1s] <- 2s
+            Expect.sequenceEqual original (dict [1s, 2s]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1s, 1s]) "Clone should not be affected by original mutation"
+        testCase "uint16 values" <| fun _ ->     
+            let d = new Dictionary<int16, uint16>()
+            d.Add(1s, 1us)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1s] <- 2us
+            Expect.sequenceEqual original (dict [1s, 2us]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1s, 1us]) "Clone should not be affected by original mutation"
+        testCase "int values" <| fun _ ->        
+            let d = new Dictionary<int16, int>()
+            d.Add(1s, 1)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1s] <- 2
+            Expect.sequenceEqual original (dict [1s, 2]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1s, 1]) "Clone should not be affected by original mutation"
+        testCase "uint values" <| fun _ ->       
+            let d = new Dictionary<int16, uint>()
+            d.Add(1s, 1u)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1s] <- 2u
+            Expect.sequenceEqual original (dict [1s, 2u]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1s, 1u]) "Clone should not be affected by original mutation"
+        testCase "int64 values" <| fun _ ->      
+            let d = new Dictionary<int16, int64>()
+            d.Add(1s, 1L)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1s] <- 2L
+            Expect.sequenceEqual original (dict [1s, 2L]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1s, 1L]) "Clone should not be affected by original mutation"
+        testCase "uint64 values" <| fun _ ->     
+            let d = new Dictionary<int16, uint64>()
+            d.Add(1s, 1uL)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1s] <- 2uL
+            Expect.sequenceEqual original (dict [1s, 2uL]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1s, 1uL]) "Clone should not be affected by original mutation"
+        testCase "float values" <| fun _ ->      
+            let d = new Dictionary<int16, float>()
+            d.Add(1s, 1.0)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1s] <- 2.0
+            Expect.sequenceEqual original (dict [1s, 2.0]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1s, 1.0]) "Clone should not be affected by original mutation"
+        testCase "float32 values" <| fun _ ->    
+            let d = new Dictionary<int16, float32>()
+            d.Add(1s, 1.0f)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1s] <- 2.0f
+            Expect.sequenceEqual original (dict [1s, 2.0f]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1s, 1.0f]) "Clone should not be affected by original mutation"
+        testCase "char values" <| fun _ ->       
+            let d = new Dictionary<int16, char>()
+            d.Add(1s, 'A')
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1s] <- 'B'
+            Expect.sequenceEqual original (dict [1s, 'B']) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1s, 'A']) "Clone should not be affected by original mutation"
+        testCase "string values" <| fun _ ->     
+            let d = new Dictionary<int16, string>()
+            d.Add(1s, "k1")
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1s] <- "k2"
+            Expect.sequenceEqual original (dict [1s, "k2"]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1s, "k1"]) "Clone should not be affected by original mutation"
+        testCase "unit values" <| fun _ ->       
+            let d = new Dictionary<int16, unit>()
+            d.Add(1s, ())
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.Add(2s,())
+            Expect.sequenceEqual original (dict [1s, (); 2s, ()]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1s, ()]) "Clone should not be affected by original mutation"
+        #if !FABLE_COMPILER_PYTHON
+        testCase "decimal values" <| fun _ ->    
+            let d = new Dictionary<int16, decimal>()
+            d.Add(1s, 1.0M)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1s] <- 2.0M
+            Expect.sequenceEqual original (dict [1s, 2.0M]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1s, 1.0M]) "Clone should not be affected by original mutation"
+        #endif
+        #if !FABLE_COMPILER
+        testCase "nativeint values" <| fun _ ->  
+            let d = new Dictionary<int16, nativeint>()
+            d.Add(1s, System.IntPtr(1))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1s] <- System.IntPtr(2)
+            Expect.sequenceEqual original (dict [1s, System.IntPtr(2)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1s, System.IntPtr(1)]) "Clone should not be affected by original mutation"
+        testCase "unativeint values" <| fun _ -> 
+            let d = new Dictionary<int16, unativeint>()
+            d.Add(1s, System.UIntPtr(1u))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1s] <- System.UIntPtr(2u)
+            Expect.sequenceEqual original (dict [1s, System.UIntPtr(2u)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1s, System.UIntPtr(1u)]) "Clone should not be affected by original mutation"
+        #endif
+    ]
+    testList "uint16 keys" [
+        testCase "bool values" <| fun _ ->
+            let d = new Dictionary<uint16, bool>()
+            d.Add(1us, true)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1us] <- false
+            Expect.sequenceEqual original (dict [1us, false]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1us, true]) "Clone should not be affected by original mutation"
+        testCase "byte values" <| fun _ ->       
+            let d = new Dictionary<uint16, byte>()
+            d.Add(1us, 1uy)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1us] <- 2uy
+            Expect.sequenceEqual original (dict [1us, 2uy]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1us, 1uy]) "Clone should not be affected by original mutation"
+        testCase "sbyte values" <| fun _ ->      
+            let d = new Dictionary<uint16, sbyte>()
+            d.Add(1us, 1y)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1us] <- 2y
+            Expect.sequenceEqual original (dict [1us, 2y]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1us, 1y]) "Clone should not be affected by original mutation"
+        testCase "int16 values" <| fun _ ->      
+            let d = new Dictionary<uint16, int16>()
+            d.Add(1us, 1s)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1us] <- 2s
+            Expect.sequenceEqual original (dict [1us, 2s]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1us, 1s]) "Clone should not be affected by original mutation"
+        testCase "uint16 values" <| fun _ ->     
+            let d = new Dictionary<uint16, uint16>()
+            d.Add(1us, 1us)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1us] <- 2us
+            Expect.sequenceEqual original (dict [1us, 2us]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1us, 1us]) "Clone should not be affected by original mutation"
+        testCase "int values" <| fun _ ->        
+            let d = new Dictionary<uint16, int>()
+            d.Add(1us, 1)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1us] <- 2
+            Expect.sequenceEqual original (dict [1us, 2]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1us, 1]) "Clone should not be affected by original mutation"
+        testCase "uint values" <| fun _ ->       
+            let d = new Dictionary<uint16, uint>()
+            d.Add(1us, 1u)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1us] <- 2u
+            Expect.sequenceEqual original (dict [1us, 2u]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1us, 1u]) "Clone should not be affected by original mutation"
+        testCase "int64 values" <| fun _ ->      
+            let d = new Dictionary<uint16, int64>()
+            d.Add(1us, 1L)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1us] <- 2L
+            Expect.sequenceEqual original (dict [1us, 2L]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1us, 1L]) "Clone should not be affected by original mutation"
+        testCase "uint64 values" <| fun _ ->     
+            let d = new Dictionary<uint16, uint64>()
+            d.Add(1us, 1uL)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1us] <- 2uL
+            Expect.sequenceEqual original (dict [1us, 2uL]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1us, 1uL]) "Clone should not be affected by original mutation"
+        testCase "float values" <| fun _ ->      
+            let d = new Dictionary<uint16, float>()
+            d.Add(1us, 1.0)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1us] <- 2.0
+            Expect.sequenceEqual original (dict [1us, 2.0]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1us, 1.0]) "Clone should not be affected by original mutation"
+        testCase "float32 values" <| fun _ ->    
+            let d = new Dictionary<uint16, float32>()
+            d.Add(1us, 1.0f)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1us] <- 2.0f
+            Expect.sequenceEqual original (dict [1us, 2.0f]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1us, 1.0f]) "Clone should not be affected by original mutation"
+        testCase "char values" <| fun _ ->       
+            let d = new Dictionary<uint16, char>()
+            d.Add(1us, 'A')
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1us] <- 'B'
+            Expect.sequenceEqual original (dict [1us, 'B']) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1us, 'A']) "Clone should not be affected by original mutation"
+        testCase "string values" <| fun _ ->     
+            let d = new Dictionary<uint16, string>()
+            d.Add(1us, "k1")
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1us] <- "k2"
+            Expect.sequenceEqual original (dict [1us, "k2"]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1us, "k1"]) "Clone should not be affected by original mutation"
+        testCase "unit values" <| fun _ ->       
+            let d = new Dictionary<uint16, unit>()
+            d.Add(1us, ())
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.Add(2us,())
+            Expect.sequenceEqual original (dict [1us, (); 2us, ()]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1us, ()]) "Clone should not be affected by original mutation"
+        #if !FABLE_COMPILER_PYTHON
+        testCase "decimal values" <| fun _ ->    
+            let d = new Dictionary<uint16, decimal>()
+            d.Add(1us, 1.0M)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1us] <- 2.0M
+            Expect.sequenceEqual original (dict [1us, 2.0M]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1us, 1.0M]) "Clone should not be affected by original mutation"
+        #endif
+        #if !FABLE_COMPILER
+        testCase "nativeint values" <| fun _ ->  
+            let d = new Dictionary<uint16, nativeint>()
+            d.Add(1us, System.IntPtr(1))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1us] <- System.IntPtr(2)
+            Expect.sequenceEqual original (dict [1us, System.IntPtr(2)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1us, System.IntPtr(1)]) "Clone should not be affected by original mutation"
+        testCase "unativeint values" <| fun _ -> 
+            let d = new Dictionary<uint16, unativeint>()
+            d.Add(1us, System.UIntPtr(1u))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1us] <- System.UIntPtr(2u)
+            Expect.sequenceEqual original (dict [1us, System.UIntPtr(2u)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1us, System.UIntPtr(1u)]) "Clone should not be affected by original mutation"
+        #endif
+    ]
+    testList "int keys" [
+        testCase "bool values" <| fun _ ->
+            let d = new Dictionary<int, bool>()
+            d.Add(1, true)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1] <- false
+            Expect.sequenceEqual original (dict [1, false]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1, true]) "Clone should not be affected by original mutation"
+        testCase "byte values" <| fun _ ->       
+            let d = new Dictionary<int, byte>()
+            d.Add(1, 1uy)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1] <- 2uy
+            Expect.sequenceEqual original (dict [1, 2uy]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1, 1uy]) "Clone should not be affected by original mutation"
+        testCase "sbyte values" <| fun _ ->      
+            let d = new Dictionary<int, sbyte>()
+            d.Add(1, 1y)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1] <- 2y
+            Expect.sequenceEqual original (dict [1, 2y]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1, 1y]) "Clone should not be affected by original mutation"
+        testCase "int16 values" <| fun _ ->      
+            let d = new Dictionary<int, int16>()
+            d.Add(1, 1s)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1] <- 2s
+            Expect.sequenceEqual original (dict [1, 2s]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1, 1s]) "Clone should not be affected by original mutation"
+        testCase "uint16 values" <| fun _ ->     
+            let d = new Dictionary<int, uint16>()
+            d.Add(1, 1us)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1] <- 2us
+            Expect.sequenceEqual original (dict [1, 2us]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1, 1us]) "Clone should not be affected by original mutation"
+        testCase "int values" <| fun _ ->        
+            let d = new Dictionary<int, int>()
+            d.Add(1, 1)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1] <- 2
+            Expect.sequenceEqual original (dict [1, 2]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1, 1]) "Clone should not be affected by original mutation"
+        testCase "uint values" <| fun _ ->       
+            let d = new Dictionary<int, uint>()
+            d.Add(1, 1u)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1] <- 2u
+            Expect.sequenceEqual original (dict [1, 2u]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1, 1u]) "Clone should not be affected by original mutation"
+        testCase "int64 values" <| fun _ ->      
+            let d = new Dictionary<int, int64>()
+            d.Add(1, 1L)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1] <- 2L
+            Expect.sequenceEqual original (dict [1, 2L]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1, 1L]) "Clone should not be affected by original mutation"
+        testCase "uint64 values" <| fun _ ->     
+            let d = new Dictionary<int, uint64>()
+            d.Add(1, 1uL)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1] <- 2uL
+            Expect.sequenceEqual original (dict [1, 2uL]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1, 1uL]) "Clone should not be affected by original mutation"
+        testCase "float values" <| fun _ ->      
+            let d = new Dictionary<int, float>()
+            d.Add(1, 1.0)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1] <- 2.0
+            Expect.sequenceEqual original (dict [1, 2.0]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1, 1.0]) "Clone should not be affected by original mutation"
+        testCase "float32 values" <| fun _ ->    
+            let d = new Dictionary<int, float32>()
+            d.Add(1, 1.0f)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1] <- 2.0f
+            Expect.sequenceEqual original (dict [1, 2.0f]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1, 1.0f]) "Clone should not be affected by original mutation"
+        testCase "char values" <| fun _ ->       
+            let d = new Dictionary<int, char>()
+            d.Add(1, 'A')
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1] <- 'B'
+            Expect.sequenceEqual original (dict [1, 'B']) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1, 'A']) "Clone should not be affected by original mutation"
+        testCase "string values" <| fun _ ->     
+            let d = new Dictionary<int, string>()
+            d.Add(1, "k1")
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1] <- "k2"
+            Expect.sequenceEqual original (dict [1, "k2"]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1, "k1"]) "Clone should not be affected by original mutation"
+        testCase "unit values" <| fun _ ->       
+            let d = new Dictionary<int, unit>()
+            d.Add(1, ())
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.Add(2,())
+            Expect.sequenceEqual original (dict [1, (); 2, ()]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1, ()]) "Clone should not be affected by original mutation"
+        #if !FABLE_COMPILER_PYTHON
+        testCase "decimal values" <| fun _ ->    
+            let d = new Dictionary<int, decimal>()
+            d.Add(1, 1.0M)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1] <- 2.0M
+            Expect.sequenceEqual original (dict [1, 2.0M]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1, 1.0M]) "Clone should not be affected by original mutation"
+        #endif
+        #if !FABLE_COMPILER
+        testCase "nativeint values" <| fun _ ->  
+            let d = new Dictionary<int, nativeint>()
+            d.Add(1, System.IntPtr(1))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1] <- System.IntPtr(2)
+            Expect.sequenceEqual original (dict [1, System.IntPtr(2)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1, System.IntPtr(1)]) "Clone should not be affected by original mutation"
+        testCase "unativeint values" <| fun _ -> 
+            let d = new Dictionary<int, unativeint>()
+            d.Add(1, System.UIntPtr(1u))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1] <- System.UIntPtr(2u)
+            Expect.sequenceEqual original (dict [1, System.UIntPtr(2u)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1, System.UIntPtr(1u)]) "Clone should not be affected by original mutation"
+        #endif
+    ]
+    testList "uint keys" [
+        testCase "bool values" <| fun _ ->
+            let d = new Dictionary<uint, bool>()
+            d.Add(1u, true)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1u] <- false
+            Expect.sequenceEqual original (dict [1u, false]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1u, true]) "Clone should not be affected by original mutation"
+        testCase "byte values" <| fun _ ->       
+            let d = new Dictionary<uint, byte>()
+            d.Add(1u, 1uy)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1u] <- 2uy
+            Expect.sequenceEqual original (dict [1u, 2uy]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1u, 1uy]) "Clone should not be affected by original mutation"
+        testCase "sbyte values" <| fun _ ->      
+            let d = new Dictionary<uint, sbyte>()
+            d.Add(1u, 1y)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1u] <- 2y
+            Expect.sequenceEqual original (dict [1u, 2y]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1u, 1y]) "Clone should not be affected by original mutation"
+        testCase "int16 values" <| fun _ ->      
+            let d = new Dictionary<uint, int16>()
+            d.Add(1u, 1s)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1u] <- 2s
+            Expect.sequenceEqual original (dict [1u, 2s]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1u, 1s]) "Clone should not be affected by original mutation"
+        testCase "uint16 values" <| fun _ ->     
+            let d = new Dictionary<uint, uint16>()
+            d.Add(1u, 1us)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1u] <- 2us
+            Expect.sequenceEqual original (dict [1u, 2us]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1u, 1us]) "Clone should not be affected by original mutation"
+        testCase "int values" <| fun _ ->        
+            let d = new Dictionary<uint, int>()
+            d.Add(1u, 1)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1u] <- 2
+            Expect.sequenceEqual original (dict [1u, 2]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1u, 1]) "Clone should not be affected by original mutation"
+        testCase "uint values" <| fun _ ->       
+            let d = new Dictionary<uint, uint>()
+            d.Add(1u, 1u)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1u] <- 2u
+            Expect.sequenceEqual original (dict [1u, 2u]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1u, 1u]) "Clone should not be affected by original mutation"
+        testCase "int64 values" <| fun _ ->      
+            let d = new Dictionary<uint, int64>()
+            d.Add(1u, 1L)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1u] <- 2L
+            Expect.sequenceEqual original (dict [1u, 2L]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1u, 1L]) "Clone should not be affected by original mutation"
+        testCase "uint64 values" <| fun _ ->     
+            let d = new Dictionary<uint, uint64>()
+            d.Add(1u, 1uL)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1u] <- 2uL
+            Expect.sequenceEqual original (dict [1u, 2uL]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1u, 1uL]) "Clone should not be affected by original mutation"
+        testCase "float values" <| fun _ ->      
+            let d = new Dictionary<uint, float>()
+            d.Add(1u, 1.0)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1u] <- 2.0
+            Expect.sequenceEqual original (dict [1u, 2.0]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1u, 1.0]) "Clone should not be affected by original mutation"
+        testCase "float32 values" <| fun _ ->    
+            let d = new Dictionary<uint, float32>()
+            d.Add(1u, 1.0f)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1u] <- 2.0f
+            Expect.sequenceEqual original (dict [1u, 2.0f]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1u, 1.0f]) "Clone should not be affected by original mutation"
+        testCase "char values" <| fun _ ->       
+            let d = new Dictionary<uint, char>()
+            d.Add(1u, 'A')
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1u] <- 'B'
+            Expect.sequenceEqual original (dict [1u, 'B']) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1u, 'A']) "Clone should not be affected by original mutation"
+        testCase "string values" <| fun _ ->     
+            let d = new Dictionary<uint, string>()
+            d.Add(1u, "k1")
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1u] <- "k2"
+            Expect.sequenceEqual original (dict [1u, "k2"]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1u, "k1"]) "Clone should not be affected by original mutation"
+        testCase "unit values" <| fun _ ->       
+            let d = new Dictionary<uint, unit>()
+            d.Add(1u, ())
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.Add(2u,())
+            Expect.sequenceEqual original (dict [1u, (); 2u, ()]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1u, ()]) "Clone should not be affected by original mutation"
+        #if !FABLE_COMPILER_PYTHON
+        testCase "decimal values" <| fun _ ->    
+            let d = new Dictionary<uint, decimal>()
+            d.Add(1u, 1.0M)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1u] <- 2.0M
+            Expect.sequenceEqual original (dict [1u, 2.0M]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1u, 1.0M]) "Clone should not be affected by original mutation"
+        #endif
+        #if !FABLE_COMPILER
+        testCase "nativeint values" <| fun _ ->  
+            let d = new Dictionary<uint, nativeint>()
+            d.Add(1u, System.IntPtr(1))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1u] <- System.IntPtr(2)
+            Expect.sequenceEqual original (dict [1u, System.IntPtr(2)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1u, System.IntPtr(1)]) "Clone should not be affected by original mutation"
+        testCase "unativeint values" <| fun _ -> 
+            let d = new Dictionary<uint, unativeint>()
+            d.Add(1u, System.UIntPtr(1u))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1u] <- System.UIntPtr(2u)
+            Expect.sequenceEqual original (dict [1u, System.UIntPtr(2u)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1u, System.UIntPtr(1u)]) "Clone should not be affected by original mutation"
+        #endif
+    ]
+    testList "int64 keys" [
+        testCase "bool values" <| fun _ ->
+            let d = new Dictionary<int64, bool>()
+            d.Add(1L, true)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1L] <- false
+            Expect.sequenceEqual original (dict [1L, false]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1L, true]) "Clone should not be affected by original mutation"
+        testCase "byte values" <| fun _ ->       
+            let d = new Dictionary<int64, byte>()
+            d.Add(1L, 1uy)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1L] <- 2uy
+            Expect.sequenceEqual original (dict [1L, 2uy]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1L, 1uy]) "Clone should not be affected by original mutation"
+        testCase "sbyte values" <| fun _ ->      
+            let d = new Dictionary<int64, sbyte>()
+            d.Add(1L, 1y)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1L] <- 2y
+            Expect.sequenceEqual original (dict [1L, 2y]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1L, 1y]) "Clone should not be affected by original mutation"
+        testCase "int16 values" <| fun _ ->      
+            let d = new Dictionary<int64, int16>()
+            d.Add(1L, 1s)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1L] <- 2s
+            Expect.sequenceEqual original (dict [1L, 2s]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1L, 1s]) "Clone should not be affected by original mutation"
+        testCase "uint16 values" <| fun _ ->     
+            let d = new Dictionary<int64, uint16>()
+            d.Add(1L, 1us)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1L] <- 2us
+            Expect.sequenceEqual original (dict [1L, 2us]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1L, 1us]) "Clone should not be affected by original mutation"
+        testCase "int values" <| fun _ ->        
+            let d = new Dictionary<int64, int>()
+            d.Add(1L, 1)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1L] <- 2
+            Expect.sequenceEqual original (dict [1L, 2]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1L, 1]) "Clone should not be affected by original mutation"
+        testCase "uint values" <| fun _ ->       
+            let d = new Dictionary<int64, uint>()
+            d.Add(1L, 1u)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1L] <- 2u
+            Expect.sequenceEqual original (dict [1L, 2u]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1L, 1u]) "Clone should not be affected by original mutation"
+        testCase "int64 values" <| fun _ ->      
+            let d = new Dictionary<int64, int64>()
+            d.Add(1L, 1L)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1L] <- 2L
+            Expect.sequenceEqual original (dict [1L, 2L]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1L, 1L]) "Clone should not be affected by original mutation"
+        testCase "uint64 values" <| fun _ ->     
+            let d = new Dictionary<int64, uint64>()
+            d.Add(1L, 1uL)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1L] <- 2uL
+            Expect.sequenceEqual original (dict [1L, 2uL]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1L, 1uL]) "Clone should not be affected by original mutation"
+        testCase "float values" <| fun _ ->      
+            let d = new Dictionary<int64, float>()
+            d.Add(1L, 1.0)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1L] <- 2.0
+            Expect.sequenceEqual original (dict [1L, 2.0]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1L, 1.0]) "Clone should not be affected by original mutation"
+        testCase "float32 values" <| fun _ ->    
+            let d = new Dictionary<int64, float32>()
+            d.Add(1L, 1.0f)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1L] <- 2.0f
+            Expect.sequenceEqual original (dict [1L, 2.0f]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1L, 1.0f]) "Clone should not be affected by original mutation"
+        testCase "char values" <| fun _ ->       
+            let d = new Dictionary<int64, char>()
+            d.Add(1L, 'A')
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1L] <- 'B'
+            Expect.sequenceEqual original (dict [1L, 'B']) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1L, 'A']) "Clone should not be affected by original mutation"
+        testCase "string values" <| fun _ ->     
+            let d = new Dictionary<int64, string>()
+            d.Add(1L, "k1")
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1L] <- "k2"
+            Expect.sequenceEqual original (dict [1L, "k2"]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1L, "k1"]) "Clone should not be affected by original mutation"
+        testCase "unit values" <| fun _ ->       
+            let d = new Dictionary<int64, unit>()
+            d.Add(1L, ())
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.Add(2L,())
+            Expect.sequenceEqual original (dict [1L, (); 2L, ()]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1L, ()]) "Clone should not be affected by original mutation"
+        #if !FABLE_COMPILER_PYTHON
+        testCase "decimal values" <| fun _ ->    
+            let d = new Dictionary<int64, decimal>()
+            d.Add(1L, 1.0M)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1L] <- 2.0M
+            Expect.sequenceEqual original (dict [1L, 2.0M]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1L, 1.0M]) "Clone should not be affected by original mutation"
+        #endif
+        #if !FABLE_COMPILER
+        testCase "nativeint values" <| fun _ ->  
+            let d = new Dictionary<int64, nativeint>()
+            d.Add(1L, System.IntPtr(1))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1L] <- System.IntPtr(2)
+            Expect.sequenceEqual original (dict [1L, System.IntPtr(2)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1L, System.IntPtr(1)]) "Clone should not be affected by original mutation"
+        testCase "unativeint values" <| fun _ -> 
+            let d = new Dictionary<int64, unativeint>()
+            d.Add(1L, System.UIntPtr(1u))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1L] <- System.UIntPtr(2u)
+            Expect.sequenceEqual original (dict [1L, System.UIntPtr(2u)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1L, System.UIntPtr(1u)]) "Clone should not be affected by original mutation"
+        #endif
+    ]
+    testList "uint64 keys" [
+        testCase "bool values" <| fun _ ->
+            let d = new Dictionary<uint64, bool>()
+            d.Add(1uL, true)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uL] <- false
+            Expect.sequenceEqual original (dict [1uL, false]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uL, true]) "Clone should not be affected by original mutation"
+        testCase "byte values" <| fun _ ->       
+            let d = new Dictionary<uint64, byte>()
+            d.Add(1uL, 1uy)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uL] <- 2uy
+            Expect.sequenceEqual original (dict [1uL, 2uy]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uL, 1uy]) "Clone should not be affected by original mutation"
+        testCase "sbyte values" <| fun _ ->      
+            let d = new Dictionary<uint64, sbyte>()
+            d.Add(1uL, 1y)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uL] <- 2y
+            Expect.sequenceEqual original (dict [1uL, 2y]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uL, 1y]) "Clone should not be affected by original mutation"
+        testCase "int16 values" <| fun _ ->      
+            let d = new Dictionary<uint64, int16>()
+            d.Add(1uL, 1s)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uL] <- 2s
+            Expect.sequenceEqual original (dict [1uL, 2s]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uL, 1s]) "Clone should not be affected by original mutation"
+        testCase "uint16 values" <| fun _ ->     
+            let d = new Dictionary<uint64, uint16>()
+            d.Add(1uL, 1us)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uL] <- 2us
+            Expect.sequenceEqual original (dict [1uL, 2us]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uL, 1us]) "Clone should not be affected by original mutation"
+        testCase "int values" <| fun _ ->        
+            let d = new Dictionary<uint64, int>()
+            d.Add(1uL, 1)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uL] <- 2
+            Expect.sequenceEqual original (dict [1uL, 2]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uL, 1]) "Clone should not be affected by original mutation"
+        testCase "uint values" <| fun _ ->       
+            let d = new Dictionary<uint64, uint>()
+            d.Add(1uL, 1u)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uL] <- 2u
+            Expect.sequenceEqual original (dict [1uL, 2u]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uL, 1u]) "Clone should not be affected by original mutation"
+        testCase "int64 values" <| fun _ ->      
+            let d = new Dictionary<uint64, int64>()
+            d.Add(1uL, 1L)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uL] <- 2L
+            Expect.sequenceEqual original (dict [1uL, 2L]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uL, 1L]) "Clone should not be affected by original mutation"
+        testCase "uint64 values" <| fun _ ->     
+            let d = new Dictionary<uint64, uint64>()
+            d.Add(1uL, 1uL)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uL] <- 2uL
+            Expect.sequenceEqual original (dict [1uL, 2uL]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uL, 1uL]) "Clone should not be affected by original mutation"
+        testCase "float values" <| fun _ ->      
+            let d = new Dictionary<uint64, float>()
+            d.Add(1uL, 1.0)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uL] <- 2.0
+            Expect.sequenceEqual original (dict [1uL, 2.0]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uL, 1.0]) "Clone should not be affected by original mutation"
+        testCase "float32 values" <| fun _ ->    
+            let d = new Dictionary<uint64, float32>()
+            d.Add(1uL, 1.0f)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uL] <- 2.0f
+            Expect.sequenceEqual original (dict [1uL, 2.0f]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uL, 1.0f]) "Clone should not be affected by original mutation"
+        testCase "char values" <| fun _ ->       
+            let d = new Dictionary<uint64, char>()
+            d.Add(1uL, 'A')
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uL] <- 'B'
+            Expect.sequenceEqual original (dict [1uL, 'B']) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uL, 'A']) "Clone should not be affected by original mutation"
+        testCase "string values" <| fun _ ->     
+            let d = new Dictionary<uint64, string>()
+            d.Add(1uL, "k1")
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uL] <- "k2"
+            Expect.sequenceEqual original (dict [1uL, "k2"]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uL, "k1"]) "Clone should not be affected by original mutation"
+        testCase "unit values" <| fun _ ->       
+            let d = new Dictionary<uint64, unit>()
+            d.Add(1uL, ())
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.Add(2uL,())
+            Expect.sequenceEqual original (dict [1uL, (); 2uL, ()]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uL, ()]) "Clone should not be affected by original mutation"
+        #if !FABLE_COMPILER_PYTHON
+        testCase "decimal values" <| fun _ ->    
+            let d = new Dictionary<uint64, decimal>()
+            d.Add(1uL, 1.0M)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uL] <- 2.0M
+            Expect.sequenceEqual original (dict [1uL, 2.0M]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uL, 1.0M]) "Clone should not be affected by original mutation"
+        #endif
+        #if !FABLE_COMPILER
+        testCase "nativeint values" <| fun _ ->  
+            let d = new Dictionary<uint64, nativeint>()
+            d.Add(1uL, System.IntPtr(1))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uL] <- System.IntPtr(2)
+            Expect.sequenceEqual original (dict [1uL, System.IntPtr(2)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uL, System.IntPtr(1)]) "Clone should not be affected by original mutation"
+        testCase "unativeint values" <| fun _ -> 
+            let d = new Dictionary<uint64, unativeint>()
+            d.Add(1uL, System.UIntPtr(1u))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1uL] <- System.UIntPtr(2u)
+            Expect.sequenceEqual original (dict [1uL, System.UIntPtr(2u)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1uL, System.UIntPtr(1u)]) "Clone should not be affected by original mutation"
+        #endif
+    ]
+    testList "float keys" [
+        testCase "bool values" <| fun _ ->
+            let d = new Dictionary<float, bool>()
+            d.Add(1.0, true)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0] <- false
+            Expect.sequenceEqual original (dict [1.0, false]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0, true]) "Clone should not be affected by original mutation"
+        testCase "byte values" <| fun _ ->       
+            let d = new Dictionary<float, byte>()
+            d.Add(1.0, 1uy)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0] <- 2uy
+            Expect.sequenceEqual original (dict [1.0, 2uy]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0, 1uy]) "Clone should not be affected by original mutation"
+        testCase "sbyte values" <| fun _ ->      
+            let d = new Dictionary<float, sbyte>()
+            d.Add(1.0, 1y)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0] <- 2y
+            Expect.sequenceEqual original (dict [1.0, 2y]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0, 1y]) "Clone should not be affected by original mutation"
+        testCase "int16 values" <| fun _ ->      
+            let d = new Dictionary<float, int16>()
+            d.Add(1.0, 1s)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0] <- 2s
+            Expect.sequenceEqual original (dict [1.0, 2s]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0, 1s]) "Clone should not be affected by original mutation"
+        testCase "uint16 values" <| fun _ ->     
+            let d = new Dictionary<float, uint16>()
+            d.Add(1.0, 1us)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0] <- 2us
+            Expect.sequenceEqual original (dict [1.0, 2us]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0, 1us]) "Clone should not be affected by original mutation"
+        testCase "int values" <| fun _ ->        
+            let d = new Dictionary<float, int>()
+            d.Add(1.0, 1)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0] <- 2
+            Expect.sequenceEqual original (dict [1.0, 2]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0, 1]) "Clone should not be affected by original mutation"
+        testCase "uint values" <| fun _ ->       
+            let d = new Dictionary<float, uint>()
+            d.Add(1.0, 1u)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0] <- 2u
+            Expect.sequenceEqual original (dict [1.0, 2u]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0, 1u]) "Clone should not be affected by original mutation"
+        testCase "int64 values" <| fun _ ->      
+            let d = new Dictionary<float, int64>()
+            d.Add(1.0, 1L)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0] <- 2L
+            Expect.sequenceEqual original (dict [1.0, 2L]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0, 1L]) "Clone should not be affected by original mutation"
+        testCase "uint64 values" <| fun _ ->     
+            let d = new Dictionary<float, uint64>()
+            d.Add(1.0, 1uL)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0] <- 2uL
+            Expect.sequenceEqual original (dict [1.0, 2uL]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0, 1uL]) "Clone should not be affected by original mutation"
+        testCase "float values" <| fun _ ->      
+            let d = new Dictionary<float, float>()
+            d.Add(1.0, 1.0)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0] <- 2.0
+            Expect.sequenceEqual original (dict [1.0, 2.0]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0, 1.0]) "Clone should not be affected by original mutation"
+        testCase "float32 values" <| fun _ ->    
+            let d = new Dictionary<float, float32>()
+            d.Add(1.0, 1.0f)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0] <- 2.0f
+            Expect.sequenceEqual original (dict [1.0, 2.0f]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0, 1.0f]) "Clone should not be affected by original mutation"
+        testCase "char values" <| fun _ ->       
+            let d = new Dictionary<float, char>()
+            d.Add(1.0, 'A')
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0] <- 'B'
+            Expect.sequenceEqual original (dict [1.0, 'B']) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0, 'A']) "Clone should not be affected by original mutation"
+        testCase "string values" <| fun _ ->     
+            let d = new Dictionary<float, string>()
+            d.Add(1.0, "k1")
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0] <- "k2"
+            Expect.sequenceEqual original (dict [1.0, "k2"]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0, "k1"]) "Clone should not be affected by original mutation"
+        testCase "unit values" <| fun _ ->       
+            let d = new Dictionary<float, unit>()
+            d.Add(1.0, ())
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.Add(2.0,())
+            Expect.sequenceEqual original (dict [1.0, (); 2.0, ()]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0, ()]) "Clone should not be affected by original mutation"
+        #if !FABLE_COMPILER_PYTHON
+        testCase "decimal values" <| fun _ ->    
+            let d = new Dictionary<float, decimal>()
+            d.Add(1.0, 1.0M)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0] <- 2.0M
+            Expect.sequenceEqual original (dict [1.0, 2.0M]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0, 1.0M]) "Clone should not be affected by original mutation"
+        #endif
+        #if !FABLE_COMPILER
+        testCase "nativeint values" <| fun _ ->  
+            let d = new Dictionary<float, nativeint>()
+            d.Add(1.0, System.IntPtr(1))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0] <- System.IntPtr(2)
+            Expect.sequenceEqual original (dict [1.0, System.IntPtr(2)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0, System.IntPtr(1)]) "Clone should not be affected by original mutation"
+        testCase "unativeint values" <| fun _ -> 
+            let d = new Dictionary<float, unativeint>()
+            d.Add(1.0, System.UIntPtr(1u))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0] <- System.UIntPtr(2u)
+            Expect.sequenceEqual original (dict [1.0, System.UIntPtr(2u)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0, System.UIntPtr(1u)]) "Clone should not be affected by original mutation"
+        #endif
+    ]
+    testList "float32 keys" [
+        testCase "bool values" <| fun _ ->
+            let d = new Dictionary<float32, bool>()
+            d.Add(1.0f, true)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0f] <- false
+            Expect.sequenceEqual original (dict [1.0f, false]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0f, true]) "Clone should not be affected by original mutation"
+        testCase "byte values" <| fun _ ->       
+            let d = new Dictionary<float32, byte>()
+            d.Add(1.0f, 1uy)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0f] <- 2uy
+            Expect.sequenceEqual original (dict [1.0f, 2uy]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0f, 1uy]) "Clone should not be affected by original mutation"
+        testCase "sbyte values" <| fun _ ->      
+            let d = new Dictionary<float32, sbyte>()
+            d.Add(1.0f, 1y)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0f] <- 2y
+            Expect.sequenceEqual original (dict [1.0f, 2y]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0f, 1y]) "Clone should not be affected by original mutation"
+        testCase "int16 values" <| fun _ ->      
+            let d = new Dictionary<float32, int16>()
+            d.Add(1.0f, 1s)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0f] <- 2s
+            Expect.sequenceEqual original (dict [1.0f, 2s]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0f, 1s]) "Clone should not be affected by original mutation"
+        testCase "uint16 values" <| fun _ ->     
+            let d = new Dictionary<float32, uint16>()
+            d.Add(1.0f, 1us)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0f] <- 2us
+            Expect.sequenceEqual original (dict [1.0f, 2us]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0f, 1us]) "Clone should not be affected by original mutation"
+        testCase "int values" <| fun _ ->        
+            let d = new Dictionary<float32, int>()
+            d.Add(1.0f, 1)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0f] <- 2
+            Expect.sequenceEqual original (dict [1.0f, 2]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0f, 1]) "Clone should not be affected by original mutation"
+        testCase "uint values" <| fun _ ->       
+            let d = new Dictionary<float32, uint>()
+            d.Add(1.0f, 1u)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0f] <- 2u
+            Expect.sequenceEqual original (dict [1.0f, 2u]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0f, 1u]) "Clone should not be affected by original mutation"
+        testCase "int64 values" <| fun _ ->      
+            let d = new Dictionary<float32, int64>()
+            d.Add(1.0f, 1L)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0f] <- 2L
+            Expect.sequenceEqual original (dict [1.0f, 2L]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0f, 1L]) "Clone should not be affected by original mutation"
+        testCase "uint64 values" <| fun _ ->     
+            let d = new Dictionary<float32, uint64>()
+            d.Add(1.0f, 1uL)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0f] <- 2uL
+            Expect.sequenceEqual original (dict [1.0f, 2uL]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0f, 1uL]) "Clone should not be affected by original mutation"
+        testCase "float values" <| fun _ ->      
+            let d = new Dictionary<float32, float>()
+            d.Add(1.0f, 1.0)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0f] <- 2.0
+            Expect.sequenceEqual original (dict [1.0f, 2.0]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0f, 1.0]) "Clone should not be affected by original mutation"
+        testCase "float32 values" <| fun _ ->    
+            let d = new Dictionary<float32, float32>()
+            d.Add(1.0f, 1.0f)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0f] <- 2.0f
+            Expect.sequenceEqual original (dict [1.0f, 2.0f]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0f, 1.0f]) "Clone should not be affected by original mutation"
+        testCase "char values" <| fun _ ->       
+            let d = new Dictionary<float32, char>()
+            d.Add(1.0f, 'A')
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0f] <- 'B'
+            Expect.sequenceEqual original (dict [1.0f, 'B']) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0f, 'A']) "Clone should not be affected by original mutation"
+        testCase "string values" <| fun _ ->     
+            let d = new Dictionary<float32, string>()
+            d.Add(1.0f, "k1")
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0f] <- "k2"
+            Expect.sequenceEqual original (dict [1.0f, "k2"]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0f, "k1"]) "Clone should not be affected by original mutation"
+        testCase "unit values" <| fun _ ->       
+            let d = new Dictionary<float32, unit>()
+            d.Add(1.0f, ())
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.Add(2.0f,())
+            Expect.sequenceEqual original (dict [1.0f, (); 2.0f, ()]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0f, ()]) "Clone should not be affected by original mutation"
+        #if !FABLE_COMPILER_PYTHON
+        testCase "decimal values" <| fun _ ->    
+            let d = new Dictionary<float32, decimal>()
+            d.Add(1.0f, 1.0M)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0f] <- 2.0M
+            Expect.sequenceEqual original (dict [1.0f, 2.0M]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0f, 1.0M]) "Clone should not be affected by original mutation"
+        #endif
+        #if !FABLE_COMPILER
+        testCase "nativeint values" <| fun _ ->  
+            let d = new Dictionary<float32, nativeint>()
+            d.Add(1.0f, System.IntPtr(1))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0f] <- System.IntPtr(2)
+            Expect.sequenceEqual original (dict [1.0f, System.IntPtr(2)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0f, System.IntPtr(1)]) "Clone should not be affected by original mutation"
+        testCase "unativeint values" <| fun _ -> 
+            let d = new Dictionary<float32, unativeint>()
+            d.Add(1.0f, System.UIntPtr(1u))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0f] <- System.UIntPtr(2u)
+            Expect.sequenceEqual original (dict [1.0f, System.UIntPtr(2u)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0f, System.UIntPtr(1u)]) "Clone should not be affected by original mutation"
+        #endif
+    ]
+    testList "char keys" [
+        testCase "bool values" <| fun _ ->
+            let d = new Dictionary<char, bool>()
+            d.Add('A', true)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.['A'] <- false
+            Expect.sequenceEqual original (dict ['A', false]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ['A', true]) "Clone should not be affected by original mutation"
+        testCase "byte values" <| fun _ ->       
+            let d = new Dictionary<char, byte>()
+            d.Add('A', 1uy)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.['A'] <- 2uy
+            Expect.sequenceEqual original (dict ['A', 2uy]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ['A', 1uy]) "Clone should not be affected by original mutation"
+        testCase "sbyte values" <| fun _ ->      
+            let d = new Dictionary<char, sbyte>()
+            d.Add('A', 1y)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.['A'] <- 2y
+            Expect.sequenceEqual original (dict ['A', 2y]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ['A', 1y]) "Clone should not be affected by original mutation"
+        testCase "int16 values" <| fun _ ->      
+            let d = new Dictionary<char, int16>()
+            d.Add('A', 1s)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.['A'] <- 2s
+            Expect.sequenceEqual original (dict ['A', 2s]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ['A', 1s]) "Clone should not be affected by original mutation"
+        testCase "uint16 values" <| fun _ ->     
+            let d = new Dictionary<char, uint16>()
+            d.Add('A', 1us)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.['A'] <- 2us
+            Expect.sequenceEqual original (dict ['A', 2us]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ['A', 1us]) "Clone should not be affected by original mutation"
+        testCase "int values" <| fun _ ->        
+            let d = new Dictionary<char, int>()
+            d.Add('A', 1)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.['A'] <- 2
+            Expect.sequenceEqual original (dict ['A', 2]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ['A', 1]) "Clone should not be affected by original mutation"
+        testCase "uint values" <| fun _ ->       
+            let d = new Dictionary<char, uint>()
+            d.Add('A', 1u)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.['A'] <- 2u
+            Expect.sequenceEqual original (dict ['A', 2u]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ['A', 1u]) "Clone should not be affected by original mutation"
+        testCase "int64 values" <| fun _ ->      
+            let d = new Dictionary<char, int64>()
+            d.Add('A', 1L)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.['A'] <- 2L
+            Expect.sequenceEqual original (dict ['A', 2L]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ['A', 1L]) "Clone should not be affected by original mutation"
+        testCase "uint64 values" <| fun _ ->     
+            let d = new Dictionary<char, uint64>()
+            d.Add('A', 1uL)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.['A'] <- 2uL
+            Expect.sequenceEqual original (dict ['A', 2uL]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ['A', 1uL]) "Clone should not be affected by original mutation"
+        testCase "float values" <| fun _ ->      
+            let d = new Dictionary<char, float>()
+            d.Add('A', 1.0)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.['A'] <- 2.0
+            Expect.sequenceEqual original (dict ['A', 2.0]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ['A', 1.0]) "Clone should not be affected by original mutation"
+        testCase "float32 values" <| fun _ ->    
+            let d = new Dictionary<char, float32>()
+            d.Add('A', 1.0f)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.['A'] <- 2.0f
+            Expect.sequenceEqual original (dict ['A', 2.0f]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ['A', 1.0f]) "Clone should not be affected by original mutation"
+        testCase "char values" <| fun _ ->       
+            let d = new Dictionary<char, char>()
+            d.Add('A', 'A')
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.['A'] <- 'B'
+            Expect.sequenceEqual original (dict ['A', 'B']) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ['A', 'A']) "Clone should not be affected by original mutation"
+        testCase "string values" <| fun _ ->     
+            let d = new Dictionary<char, string>()
+            d.Add('A', "k1")
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.['A'] <- "k2"
+            Expect.sequenceEqual original (dict ['A', "k2"]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ['A', "k1"]) "Clone should not be affected by original mutation"
+        testCase "unit values" <| fun _ ->       
+            let d = new Dictionary<char, unit>()
+            d.Add('A', ())
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.Add('B',())
+            Expect.sequenceEqual original (dict ['A', (); 'B', ()]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ['A', ()]) "Clone should not be affected by original mutation"
+        #if !FABLE_COMPILER_PYTHON
+        testCase "decimal values" <| fun _ ->    
+            let d = new Dictionary<char, decimal>()
+            d.Add('A', 1.0M)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.['A'] <- 2.0M
+            Expect.sequenceEqual original (dict ['A', 2.0M]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ['A', 1.0M]) "Clone should not be affected by original mutation"
+        #endif
+        #if !FABLE_COMPILER
+        testCase "nativeint values" <| fun _ ->  
+            let d = new Dictionary<char, nativeint>()
+            d.Add('A', System.IntPtr(1))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.['A'] <- System.IntPtr(2)
+            Expect.sequenceEqual original (dict ['A', System.IntPtr(2)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ['A', System.IntPtr(1)]) "Clone should not be affected by original mutation"
+        testCase "unativeint values" <| fun _ -> 
+            let d = new Dictionary<char, unativeint>()
+            d.Add('A', System.UIntPtr(1u))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.['A'] <- System.UIntPtr(2u)
+            Expect.sequenceEqual original (dict ['A', System.UIntPtr(2u)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ['A', System.UIntPtr(1u)]) "Clone should not be affected by original mutation"
+        #endif
+    ]
+    testList "string keys" [
+        testCase "bool values" <| fun _ ->
+            let d = new Dictionary<string, bool>()
+            d.Add("Hi", true)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.["Hi"] <- false
+            Expect.sequenceEqual original (dict ["Hi", false]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ["Hi", true]) "Clone should not be affected by original mutation"
+        testCase "byte values" <| fun _ ->       
+            let d = new Dictionary<string, byte>()
+            d.Add("Hi", 1uy)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.["Hi"] <- 2uy
+            Expect.sequenceEqual original (dict ["Hi", 2uy]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ["Hi", 1uy]) "Clone should not be affected by original mutation"
+        testCase "sbyte values" <| fun _ ->      
+            let d = new Dictionary<string, sbyte>()
+            d.Add("Hi", 1y)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.["Hi"] <- 2y
+            Expect.sequenceEqual original (dict ["Hi", 2y]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ["Hi", 1y]) "Clone should not be affected by original mutation"
+        testCase "int16 values" <| fun _ ->      
+            let d = new Dictionary<string, int16>()
+            d.Add("Hi", 1s)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.["Hi"] <- 2s
+            Expect.sequenceEqual original (dict ["Hi", 2s]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ["Hi", 1s]) "Clone should not be affected by original mutation"
+        testCase "uint16 values" <| fun _ ->     
+            let d = new Dictionary<string, uint16>()
+            d.Add("Hi", 1us)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.["Hi"] <- 2us
+            Expect.sequenceEqual original (dict ["Hi", 2us]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ["Hi", 1us]) "Clone should not be affected by original mutation"
+        testCase "int values" <| fun _ ->        
+            let d = new Dictionary<string, int>()
+            d.Add("Hi", 1)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.["Hi"] <- 2
+            Expect.sequenceEqual original (dict ["Hi", 2]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ["Hi", 1]) "Clone should not be affected by original mutation"
+        testCase "uint values" <| fun _ ->       
+            let d = new Dictionary<string, uint>()
+            d.Add("Hi", 1u)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.["Hi"] <- 2u
+            Expect.sequenceEqual original (dict ["Hi", 2u]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ["Hi", 1u]) "Clone should not be affected by original mutation"
+        testCase "int64 values" <| fun _ ->      
+            let d = new Dictionary<string, int64>()
+            d.Add("Hi", 1L)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.["Hi"] <- 2L
+            Expect.sequenceEqual original (dict ["Hi", 2L]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ["Hi", 1L]) "Clone should not be affected by original mutation"
+        testCase "uint64 values" <| fun _ ->     
+            let d = new Dictionary<string, uint64>()
+            d.Add("Hi", 1uL)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.["Hi"] <- 2uL
+            Expect.sequenceEqual original (dict ["Hi", 2uL]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ["Hi", 1uL]) "Clone should not be affected by original mutation"
+        testCase "float values" <| fun _ ->      
+            let d = new Dictionary<string, float>()
+            d.Add("Hi", 1.0)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.["Hi"] <- 2.0
+            Expect.sequenceEqual original (dict ["Hi", 2.0]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ["Hi", 1.0]) "Clone should not be affected by original mutation"
+        testCase "float32 values" <| fun _ ->    
+            let d = new Dictionary<string, float32>()
+            d.Add("Hi", 1.0f)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.["Hi"] <- 2.0f
+            Expect.sequenceEqual original (dict ["Hi", 2.0f]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ["Hi", 1.0f]) "Clone should not be affected by original mutation"
+        testCase "char values" <| fun _ ->       
+            let d = new Dictionary<string, char>()
+            d.Add("Hi", 'A')
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.["Hi"] <- 'B'
+            Expect.sequenceEqual original (dict ["Hi", 'B']) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ["Hi", 'A']) "Clone should not be affected by original mutation"
+        testCase "string values" <| fun _ ->     
+            let d = new Dictionary<string, string>()
+            d.Add("Hi", "k1")
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.["Hi"] <- "k2"
+            Expect.sequenceEqual original (dict ["Hi", "k2"]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ["Hi", "k1"]) "Clone should not be affected by original mutation"
+        testCase "unit values" <| fun _ ->       
+            let d = new Dictionary<string, unit>()
+            d.Add("Hi", ())
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.Add("Bye",())
+            Expect.sequenceEqual original (dict ["Hi", (); "Bye", ()]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ["Hi", ()]) "Clone should not be affected by original mutation"
+        #if !FABLE_COMPILER_PYTHON
+        testCase "decimal values" <| fun _ ->    
+            let d = new Dictionary<string, decimal>()
+            d.Add("Hi", 1.0M)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.["Hi"] <- 2.0M
+            Expect.sequenceEqual original (dict ["Hi", 2.0M]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ["Hi", 1.0M]) "Clone should not be affected by original mutation"
+        #endif
+        #if !FABLE_COMPILER
+        testCase "nativeint values" <| fun _ ->  
+            let d = new Dictionary<string, nativeint>()
+            d.Add("Hi", System.IntPtr(1))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.["Hi"] <- System.IntPtr(2)
+            Expect.sequenceEqual original (dict ["Hi", System.IntPtr(2)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ["Hi", System.IntPtr(1)]) "Clone should not be affected by original mutation"
+        testCase "unativeint values" <| fun _ -> 
+            let d = new Dictionary<string, unativeint>()
+            d.Add("Hi", System.UIntPtr(1u))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.["Hi"] <- System.UIntPtr(2u)
+            Expect.sequenceEqual original (dict ["Hi", System.UIntPtr(2u)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict ["Hi", System.UIntPtr(1u)]) "Clone should not be affected by original mutation"
+        #endif
+    ]
     //testList "unit keys" [
-
+    //not testing this, the concept is ridiculous
     //]
     #if !FABLE_COMPILER_PYTHON
-    //testList "decimal keys" [
-
-    //]
+    testList "decimal keys" [
+        testCase "bool values" <| fun _ ->
+            let d = new Dictionary<decimal, bool>()
+            d.Add(1.0M, true)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0M] <- false
+            Expect.sequenceEqual original (dict [1.0M, false]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0M, true]) "Clone should not be affected by original mutation"
+        testCase "byte values" <| fun _ ->       
+            let d = new Dictionary<decimal, byte>()
+            d.Add(1.0M, 1uy)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0M] <- 2uy
+            Expect.sequenceEqual original (dict [1.0M, 2uy]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0M, 1uy]) "Clone should not be affected by original mutation"
+        testCase "sbyte values" <| fun _ ->      
+            let d = new Dictionary<decimal, sbyte>()
+            d.Add(1.0M, 1y)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0M] <- 2y
+            Expect.sequenceEqual original (dict [1.0M, 2y]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0M, 1y]) "Clone should not be affected by original mutation"
+        testCase "int16 values" <| fun _ ->      
+            let d = new Dictionary<decimal, int16>()
+            d.Add(1.0M, 1s)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0M] <- 2s
+            Expect.sequenceEqual original (dict [1.0M, 2s]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0M, 1s]) "Clone should not be affected by original mutation"
+        testCase "uint16 values" <| fun _ ->     
+            let d = new Dictionary<decimal, uint16>()
+            d.Add(1.0M, 1us)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0M] <- 2us
+            Expect.sequenceEqual original (dict [1.0M, 2us]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0M, 1us]) "Clone should not be affected by original mutation"
+        testCase "int values" <| fun _ ->        
+            let d = new Dictionary<decimal, int>()
+            d.Add(1.0M, 1)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0M] <- 2
+            Expect.sequenceEqual original (dict [1.0M, 2]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0M, 1]) "Clone should not be affected by original mutation"
+        testCase "uint values" <| fun _ ->       
+            let d = new Dictionary<decimal, uint>()
+            d.Add(1.0M, 1u)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0M] <- 2u
+            Expect.sequenceEqual original (dict [1.0M, 2u]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0M, 1u]) "Clone should not be affected by original mutation"
+        testCase "int64 values" <| fun _ ->      
+            let d = new Dictionary<decimal, int64>()
+            d.Add(1.0M, 1L)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0M] <- 2L
+            Expect.sequenceEqual original (dict [1.0M, 2L]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0M, 1L]) "Clone should not be affected by original mutation"
+        testCase "uint64 values" <| fun _ ->     
+            let d = new Dictionary<decimal, uint64>()
+            d.Add(1.0M, 1uL)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0M] <- 2uL
+            Expect.sequenceEqual original (dict [1.0M, 2uL]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0M, 1uL]) "Clone should not be affected by original mutation"
+        testCase "float values" <| fun _ ->      
+            let d = new Dictionary<decimal, float>()
+            d.Add(1.0M, 1.0)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0M] <- 2.0
+            Expect.sequenceEqual original (dict [1.0M, 2.0]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0M, 1.0]) "Clone should not be affected by original mutation"
+        testCase "float32 values" <| fun _ ->    
+            let d = new Dictionary<decimal, float32>()
+            d.Add(1.0M, 1.0f)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0M] <- 2.0f
+            Expect.sequenceEqual original (dict [1.0M, 2.0f]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0M, 1.0f]) "Clone should not be affected by original mutation"
+        testCase "char values" <| fun _ ->       
+            let d = new Dictionary<decimal, char>()
+            d.Add(1.0M, 'A')
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0M] <- 'B'
+            Expect.sequenceEqual original (dict [1.0M, 'B']) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0M, 'A']) "Clone should not be affected by original mutation"
+        testCase "string values" <| fun _ ->     
+            let d = new Dictionary<decimal, string>()
+            d.Add(1.0M, "k1")
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0M] <- "k2"
+            Expect.sequenceEqual original (dict [1.0M, "k2"]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0M, "k1"]) "Clone should not be affected by original mutation"
+        testCase "unit values" <| fun _ ->       
+            let d = new Dictionary<decimal, unit>()
+            d.Add(1.0M, ())
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.Add(2.0M,())
+            Expect.sequenceEqual original (dict [1.0M, (); 2.0M, ()]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0M, ()]) "Clone should not be affected by original mutation"
+        #if !FABLE_COMPILER_PYTHON
+        testCase "decimal values" <| fun _ ->    
+            let d = new Dictionary<decimal, decimal>()
+            d.Add(1.0M, 1.0M)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0M] <- 2.0M
+            Expect.sequenceEqual original (dict [1.0M, 2.0M]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0M, 1.0M]) "Clone should not be affected by original mutation"
+        #endif
+        #if !FABLE_COMPILER
+        testCase "nativeint values" <| fun _ ->  
+            let d = new Dictionary<decimal, nativeint>()
+            d.Add(1.0M, System.IntPtr(1))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0M] <- System.IntPtr(2)
+            Expect.sequenceEqual original (dict [1.0M, System.IntPtr(2)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0M, System.IntPtr(1)]) "Clone should not be affected by original mutation"
+        testCase "unativeint values" <| fun _ -> 
+            let d = new Dictionary<decimal, unativeint>()
+            d.Add(1.0M, System.UIntPtr(1u))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[1.0M] <- System.UIntPtr(2u)
+            Expect.sequenceEqual original (dict [1.0M, System.UIntPtr(2u)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [1.0M, System.UIntPtr(1u)]) "Clone should not be affected by original mutation"
+        #endif
+    ]
     #endif
     #if !FABLE_COMPILER
-    //testList "nativeint keys" [
-
-    //]
-    //testList "unativeint keys" [
-
-    //]
+    testList "nativeint keys" [
+        testCase "bool values" <| fun _ ->
+            let d = new Dictionary<nativeint, bool>()
+            d.Add(System.IntPtr(1), true)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.IntPtr(1)] <- false
+            Expect.sequenceEqual original (dict [System.IntPtr(1), false]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.IntPtr(1), true]) "Clone should not be affected by original mutation"
+        testCase "byte values" <| fun _ ->       
+            let d = new Dictionary<nativeint, byte>()
+            d.Add(System.IntPtr(1), 1uy)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.IntPtr(1)] <- 2uy
+            Expect.sequenceEqual original (dict [System.IntPtr(1), 2uy]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.IntPtr(1), 1uy]) "Clone should not be affected by original mutation"
+        testCase "sbyte values" <| fun _ ->      
+            let d = new Dictionary<nativeint, sbyte>()
+            d.Add(System.IntPtr(1), 1y)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.IntPtr(1)] <- 2y
+            Expect.sequenceEqual original (dict [System.IntPtr(1), 2y]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.IntPtr(1), 1y]) "Clone should not be affected by original mutation"
+        testCase "int16 values" <| fun _ ->      
+            let d = new Dictionary<nativeint, int16>()
+            d.Add(System.IntPtr(1), 1s)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.IntPtr(1)] <- 2s
+            Expect.sequenceEqual original (dict [System.IntPtr(1), 2s]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.IntPtr(1), 1s]) "Clone should not be affected by original mutation"
+        testCase "uint16 values" <| fun _ ->     
+            let d = new Dictionary<nativeint, uint16>()
+            d.Add(System.IntPtr(1), 1us)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.IntPtr(1)] <- 2us
+            Expect.sequenceEqual original (dict [System.IntPtr(1), 2us]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.IntPtr(1), 1us]) "Clone should not be affected by original mutation"
+        testCase "int values" <| fun _ ->        
+            let d = new Dictionary<nativeint, int>()
+            d.Add(System.IntPtr(1), 1)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.IntPtr(1)] <- 2
+            Expect.sequenceEqual original (dict [System.IntPtr(1), 2]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.IntPtr(1), 1]) "Clone should not be affected by original mutation"
+        testCase "uint values" <| fun _ ->       
+            let d = new Dictionary<nativeint, uint>()
+            d.Add(System.IntPtr(1), 1u)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.IntPtr(1)] <- 2u
+            Expect.sequenceEqual original (dict [System.IntPtr(1), 2u]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.IntPtr(1), 1u]) "Clone should not be affected by original mutation"
+        testCase "int64 values" <| fun _ ->      
+            let d = new Dictionary<nativeint, int64>()
+            d.Add(System.IntPtr(1), 1L)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.IntPtr(1)] <- 2L
+            Expect.sequenceEqual original (dict [System.IntPtr(1), 2L]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.IntPtr(1), 1L]) "Clone should not be affected by original mutation"
+        testCase "uint64 values" <| fun _ ->     
+            let d = new Dictionary<nativeint, uint64>()
+            d.Add(System.IntPtr(1), 1uL)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.IntPtr(1)] <- 2uL
+            Expect.sequenceEqual original (dict [System.IntPtr(1), 2uL]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.IntPtr(1), 1uL]) "Clone should not be affected by original mutation"
+        testCase "float values" <| fun _ ->      
+            let d = new Dictionary<nativeint, float>()
+            d.Add(System.IntPtr(1), 1.0)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.IntPtr(1)] <- 2.0
+            Expect.sequenceEqual original (dict [System.IntPtr(1), 2.0]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.IntPtr(1), 1.0]) "Clone should not be affected by original mutation"
+        testCase "float32 values" <| fun _ ->    
+            let d = new Dictionary<nativeint, float32>()
+            d.Add(System.IntPtr(1), 1.0f)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.IntPtr(1)] <- 2.0f
+            Expect.sequenceEqual original (dict [System.IntPtr(1), 2.0f]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.IntPtr(1), 1.0f]) "Clone should not be affected by original mutation"
+        testCase "char values" <| fun _ ->       
+            let d = new Dictionary<nativeint, char>()
+            d.Add(System.IntPtr(1), 'A')
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.IntPtr(1)] <- 'B'
+            Expect.sequenceEqual original (dict [System.IntPtr(1), 'B']) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.IntPtr(1), 'A']) "Clone should not be affected by original mutation"
+        testCase "string values" <| fun _ ->     
+            let d = new Dictionary<nativeint, string>()
+            d.Add(System.IntPtr(1), "k1")
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.IntPtr(1)] <- "k2"
+            Expect.sequenceEqual original (dict [System.IntPtr(1), "k2"]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.IntPtr(1), "k1"]) "Clone should not be affected by original mutation"
+        testCase "unit values" <| fun _ ->       
+            let d = new Dictionary<nativeint, unit>()
+            d.Add(System.IntPtr(1), ())
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.Add(System.IntPtr(2),())
+            Expect.sequenceEqual original (dict [System.IntPtr(1), (); System.IntPtr(2), ()]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.IntPtr(1), ()]) "Clone should not be affected by original mutation"
+        #if !FABLE_COMPILER_PYTHON
+        testCase "decimal values" <| fun _ ->    
+            let d = new Dictionary<nativeint, decimal>()
+            d.Add(System.IntPtr(1), 1.0M)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.IntPtr(1)] <- 2.0M
+            Expect.sequenceEqual original (dict [System.IntPtr(1), 2.0M]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.IntPtr(1), 1.0M]) "Clone should not be affected by original mutation"
+        #endif
+        #if !FABLE_COMPILER
+        testCase "nativeint values" <| fun _ ->  
+            let d = new Dictionary<nativeint, nativeint>()
+            d.Add(System.IntPtr(1), System.IntPtr(1))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.IntPtr(1)] <- System.IntPtr(2)
+            Expect.sequenceEqual original (dict [System.IntPtr(1), System.IntPtr(2)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.IntPtr(1), System.IntPtr(1)]) "Clone should not be affected by original mutation"
+        testCase "unativeint values" <| fun _ -> 
+            let d = new Dictionary<nativeint, unativeint>()
+            d.Add(System.IntPtr(1), System.UIntPtr(1u))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.IntPtr(1)] <- System.UIntPtr(2u)
+            Expect.sequenceEqual original (dict [System.IntPtr(1), System.UIntPtr(2u)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.IntPtr(1), System.UIntPtr(1u)]) "Clone should not be affected by original mutation"
+        #endif
+    ]
+    testList "unativeint keys" [
+        testCase "bool values" <| fun _ ->
+            let d = new Dictionary<unativeint, bool>()
+            d.Add(System.UIntPtr(1u), true)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.UIntPtr(1u)] <- false
+            Expect.sequenceEqual original (dict [System.UIntPtr(1u), false]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.UIntPtr(1u), true]) "Clone should not be affected by original mutation"
+        testCase "byte values" <| fun _ ->       
+            let d = new Dictionary<unativeint, byte>()
+            d.Add(System.UIntPtr(1u), 1uy)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.UIntPtr(1u)] <- 2uy
+            Expect.sequenceEqual original (dict [System.UIntPtr(1u), 2uy]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.UIntPtr(1u), 1uy]) "Clone should not be affected by original mutation"
+        testCase "sbyte values" <| fun _ ->      
+            let d = new Dictionary<unativeint, sbyte>()
+            d.Add(System.UIntPtr(1u), 1y)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.UIntPtr(1u)] <- 2y
+            Expect.sequenceEqual original (dict [System.UIntPtr(1u), 2y]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.UIntPtr(1u), 1y]) "Clone should not be affected by original mutation"
+        testCase "int16 values" <| fun _ ->      
+            let d = new Dictionary<unativeint, int16>()
+            d.Add(System.UIntPtr(1u), 1s)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.UIntPtr(1u)] <- 2s
+            Expect.sequenceEqual original (dict [System.UIntPtr(1u), 2s]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.UIntPtr(1u), 1s]) "Clone should not be affected by original mutation"
+        testCase "uint16 values" <| fun _ ->     
+            let d = new Dictionary<unativeint, uint16>()
+            d.Add(System.UIntPtr(1u), 1us)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.UIntPtr(1u)] <- 2us
+            Expect.sequenceEqual original (dict [System.UIntPtr(1u), 2us]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.UIntPtr(1u), 1us]) "Clone should not be affected by original mutation"
+        testCase "int values" <| fun _ ->        
+            let d = new Dictionary<unativeint, int>()
+            d.Add(System.UIntPtr(1u), 1)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.UIntPtr(1u)] <- 2
+            Expect.sequenceEqual original (dict [System.UIntPtr(1u), 2]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.UIntPtr(1u), 1]) "Clone should not be affected by original mutation"
+        testCase "uint values" <| fun _ ->       
+            let d = new Dictionary<unativeint, uint>()
+            d.Add(System.UIntPtr(1u), 1u)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.UIntPtr(1u)] <- 2u
+            Expect.sequenceEqual original (dict [System.UIntPtr(1u), 2u]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.UIntPtr(1u), 1u]) "Clone should not be affected by original mutation"
+        testCase "int64 values" <| fun _ ->      
+            let d = new Dictionary<unativeint, int64>()
+            d.Add(System.UIntPtr(1u), 1L)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.UIntPtr(1u)] <- 2L
+            Expect.sequenceEqual original (dict [System.UIntPtr(1u), 2L]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.UIntPtr(1u), 1L]) "Clone should not be affected by original mutation"
+        testCase "uint64 values" <| fun _ ->     
+            let d = new Dictionary<unativeint, uint64>()
+            d.Add(System.UIntPtr(1u), 1uL)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.UIntPtr(1u)] <- 2uL
+            Expect.sequenceEqual original (dict [System.UIntPtr(1u), 2uL]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.UIntPtr(1u), 1uL]) "Clone should not be affected by original mutation"
+        testCase "float values" <| fun _ ->      
+            let d = new Dictionary<unativeint, float>()
+            d.Add(System.UIntPtr(1u), 1.0)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.UIntPtr(1u)] <- 2.0
+            Expect.sequenceEqual original (dict [System.UIntPtr(1u), 2.0]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.UIntPtr(1u), 1.0]) "Clone should not be affected by original mutation"
+        testCase "float32 values" <| fun _ ->    
+            let d = new Dictionary<unativeint, float32>()
+            d.Add(System.UIntPtr(1u), 1.0f)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.UIntPtr(1u)] <- 2.0f
+            Expect.sequenceEqual original (dict [System.UIntPtr(1u), 2.0f]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.UIntPtr(1u), 1.0f]) "Clone should not be affected by original mutation"
+        testCase "char values" <| fun _ ->       
+            let d = new Dictionary<unativeint, char>()
+            d.Add(System.UIntPtr(1u), 'A')
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.UIntPtr(1u)] <- 'B'
+            Expect.sequenceEqual original (dict [System.UIntPtr(1u), 'B']) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.UIntPtr(1u), 'A']) "Clone should not be affected by original mutation"
+        testCase "string values" <| fun _ ->     
+            let d = new Dictionary<unativeint, string>()
+            d.Add(System.UIntPtr(1u), "k1")
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.UIntPtr(1u)] <- "k2"
+            Expect.sequenceEqual original (dict [System.UIntPtr(1u), "k2"]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.UIntPtr(1u), "k1"]) "Clone should not be affected by original mutation"
+        testCase "unit values" <| fun _ ->       
+            let d = new Dictionary<unativeint, unit>()
+            d.Add(System.UIntPtr(1u), ())
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.Add(System.UIntPtr(2u),())
+            Expect.sequenceEqual original (dict [System.UIntPtr(1u), (); System.UIntPtr(2u), ()]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.UIntPtr(1u), ()]) "Clone should not be affected by original mutation"
+        #if !FABLE_COMPILER_PYTHON
+        testCase "decimal values" <| fun _ ->    
+            let d = new Dictionary<unativeint, decimal>()
+            d.Add(System.UIntPtr(1u), 1.0M)
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.UIntPtr(1u)] <- 2.0M
+            Expect.sequenceEqual original (dict [System.UIntPtr(1u), 2.0M]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.UIntPtr(1u), 1.0M]) "Clone should not be affected by original mutation"
+        #endif
+        #if !FABLE_COMPILER
+        testCase "nativeint values" <| fun _ ->  
+            let d = new Dictionary<unativeint, nativeint>()
+            d.Add(System.UIntPtr(1u), System.IntPtr(1))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.UIntPtr(1u)] <- System.IntPtr(2)
+            Expect.sequenceEqual original (dict [System.UIntPtr(1u), System.IntPtr(2)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.UIntPtr(1u), System.IntPtr(1)]) "Clone should not be affected by original mutation"
+        testCase "unativeint values" <| fun _ -> 
+            let d = new Dictionary<unativeint, unativeint>()
+            d.Add(System.UIntPtr(1u), System.UIntPtr(1u))
+            let original, copy = constructDeepCopiedObj d
+            Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
+            Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+            d.[System.UIntPtr(1u)] <- System.UIntPtr(2u)
+            Expect.sequenceEqual original (dict [System.UIntPtr(1u), System.UIntPtr(2u)]) "Original schould have been mutated"
+            Expect.sequenceEqual copy (dict [System.UIntPtr(1u), System.UIntPtr(1u)]) "Clone should not be affected by original mutation"
+        #endif
+    ]
     #endif
 ]

--- a/tests/DynamicObject.Tests/CopyUtils.tryDeepCopyObj/DynamicObj.fs
+++ b/tests/DynamicObject.Tests/CopyUtils.tryDeepCopyObj/DynamicObj.fs
@@ -1,0 +1,2 @@
+﻿module DeepCopyDynamicObj
+

--- a/tests/DynamicObject.Tests/CopyUtils.tryDeepCopyObj/DynamicObjCollections.fs
+++ b/tests/DynamicObject.Tests/CopyUtils.tryDeepCopyObj/DynamicObjCollections.fs
@@ -1,0 +1,2 @@
+﻿module DeepCopyDynamicObjCollections
+

--- a/tests/DynamicObject.Tests/CopyUtils.tryDeepCopyObj/ICloneable.fs
+++ b/tests/DynamicObject.Tests/CopyUtils.tryDeepCopyObj/ICloneable.fs
@@ -1,0 +1,2 @@
+﻿module DeepCopyICloneable
+

--- a/tests/DynamicObject.Tests/CopyUtils.tryDeepCopyObj/Main.fs
+++ b/tests/DynamicObject.Tests/CopyUtils.tryDeepCopyObj/Main.fs
@@ -7,5 +7,7 @@ open Fable.Core
 
 let main = testList "CopyUtils.tryDeepCopyObj" [
     DeepCopyPrimitives.tests_DeepCopyPrimitives
+    DeepCopyResizeArrays.tests_DeepCopyResizeArrays
+    DeepCopyDictionaries.tests_DeepCopyDictionaries
 ]
 

--- a/tests/DynamicObject.Tests/CopyUtils.tryDeepCopyObj/Main.fs
+++ b/tests/DynamicObject.Tests/CopyUtils.tryDeepCopyObj/Main.fs
@@ -1,0 +1,11 @@
+﻿module CopyUtils.Tests
+
+open System
+open Fable.Pyxpecto
+open DynamicObj
+open Fable.Core
+
+let main = testList "CopyUtils.tryDeepCopyObj" [
+    DeepCopyPrimitives.tests_DeepCopyPrimitives
+]
+

--- a/tests/DynamicObject.Tests/CopyUtils.tryDeepCopyObj/Primitives.fs
+++ b/tests/DynamicObject.Tests/CopyUtils.tryDeepCopyObj/Primitives.fs
@@ -1,0 +1,58 @@
+﻿module DeepCopyPrimitives
+
+open System
+open Fable.Pyxpecto
+open DynamicObj
+open Fable.Core
+open TestUtils
+
+let tests_DeepCopyPrimitives = testList "" [
+    testCase "" <| fun _ -> 
+        let original, copy = constructDeepCopiedObj true
+        Expect.equal copy original "Expected values of copy and original to be equal"
+    testCase "" <| fun _ -> 
+        let original, copy = constructDeepCopiedObj 1uy
+        Expect.equal copy original "Expected values of copy and original to be equal"
+    testCase "" <| fun _ -> 
+        let original, copy = constructDeepCopiedObj 1y
+        Expect.equal copy original "Expected values of copy and original to be equal"
+    testCase "" <| fun _ -> 
+        let original, copy = constructDeepCopiedObj 1s
+        Expect.equal copy original "Expected values of copy and original to be equal"
+    testCase "" <| fun _ -> 
+        let original, copy = constructDeepCopiedObj 1us
+        Expect.equal copy original "Expected values of copy and original to be equal"
+    testCase "" <| fun _ -> 
+        let original, copy = constructDeepCopiedObj 1
+        Expect.equal copy original "Expected values of copy and original to be equal"
+    testCase "" <| fun _ -> 
+        let original, copy = constructDeepCopiedObj 1u
+        Expect.equal copy original "Expected values of copy and original to be equal"
+    testCase "" <| fun _ -> 
+        let original, copy = constructDeepCopiedObj 1L
+        Expect.equal copy original "Expected values of copy and original to be equal"
+    testCase "" <| fun _ -> 
+        let original, copy = constructDeepCopiedObj 1uL
+        Expect.equal copy original "Expected values of copy and original to be equal"
+    testCase "" <| fun _ -> 
+        let original, copy = constructDeepCopiedObj (System.IntPtr(1))
+        Expect.equal copy original "Expected values of copy and original to be equal"
+    testCase "" <| fun _ -> 
+        let original, copy = constructDeepCopiedObj (System.UIntPtr(1u))
+        Expect.equal copy original "Expected values of copy and original to be equal"
+    testCase "" <| fun _ -> 
+        let original, copy = constructDeepCopiedObj 1.0
+        Expect.equal copy original "Expected values of copy and original to be equal"
+    testCase "" <| fun _ -> 
+        let original, copy = constructDeepCopiedObj 1.0f
+        Expect.equal copy original "Expected values of copy and original to be equal"
+    testCase "" <| fun _ -> 
+        let original, copy = constructDeepCopiedObj 'A'
+        Expect.equal copy original "Expected values of copy and original to be equal"
+    testCase "" <| fun _ -> 
+        let original, copy = constructDeepCopiedObj "Hi"
+        Expect.equal copy original "Expected values of copy and original to be equal"
+    testCase "" <| fun _ -> 
+        let original, copy = constructDeepCopiedObj ()
+        Expect.equal copy original "Expected values of copy and original to be equal"
+]

--- a/tests/DynamicObject.Tests/CopyUtils.tryDeepCopyObj/Primitives.fs
+++ b/tests/DynamicObject.Tests/CopyUtils.tryDeepCopyObj/Primitives.fs
@@ -6,53 +6,55 @@ open DynamicObj
 open Fable.Core
 open TestUtils
 
-let tests_DeepCopyPrimitives = testList "" [
-    testCase "" <| fun _ -> 
+let tests_DeepCopyPrimitives = testList "Primitives" [
+    testCase "bool" <| fun _ -> 
         let original, copy = constructDeepCopiedObj true
         Expect.equal copy original "Expected values of copy and original to be equal"
-    testCase "" <| fun _ -> 
+    testCase "byte" <| fun _ -> 
         let original, copy = constructDeepCopiedObj 1uy
         Expect.equal copy original "Expected values of copy and original to be equal"
-    testCase "" <| fun _ -> 
+    testCase "sbyte" <| fun _ -> 
         let original, copy = constructDeepCopiedObj 1y
         Expect.equal copy original "Expected values of copy and original to be equal"
-    testCase "" <| fun _ -> 
+    testCase "int16" <| fun _ -> 
         let original, copy = constructDeepCopiedObj 1s
         Expect.equal copy original "Expected values of copy and original to be equal"
-    testCase "" <| fun _ -> 
+    testCase "uint16" <| fun _ -> 
         let original, copy = constructDeepCopiedObj 1us
         Expect.equal copy original "Expected values of copy and original to be equal"
-    testCase "" <| fun _ -> 
+    testCase "int" <| fun _ -> 
         let original, copy = constructDeepCopiedObj 1
         Expect.equal copy original "Expected values of copy and original to be equal"
-    testCase "" <| fun _ -> 
+    testCase "uint" <| fun _ -> 
         let original, copy = constructDeepCopiedObj 1u
         Expect.equal copy original "Expected values of copy and original to be equal"
-    testCase "" <| fun _ -> 
+    testCase "int64" <| fun _ -> 
         let original, copy = constructDeepCopiedObj 1L
         Expect.equal copy original "Expected values of copy and original to be equal"
-    testCase "" <| fun _ -> 
+    testCase "uint64" <| fun _ -> 
         let original, copy = constructDeepCopiedObj 1uL
         Expect.equal copy original "Expected values of copy and original to be equal"
-    testCase "" <| fun _ -> 
+    #if !FABLE_COMPILER
+    testCase "nativeint" <| fun _ -> 
         let original, copy = constructDeepCopiedObj (System.IntPtr(1))
         Expect.equal copy original "Expected values of copy and original to be equal"
-    testCase "" <| fun _ -> 
+    testCase "unativeint" <| fun _ -> 
         let original, copy = constructDeepCopiedObj (System.UIntPtr(1u))
         Expect.equal copy original "Expected values of copy and original to be equal"
-    testCase "" <| fun _ -> 
+    #endif
+    testCase "float" <| fun _ -> 
         let original, copy = constructDeepCopiedObj 1.0
         Expect.equal copy original "Expected values of copy and original to be equal"
-    testCase "" <| fun _ -> 
+    testCase "float32" <| fun _ -> 
         let original, copy = constructDeepCopiedObj 1.0f
         Expect.equal copy original "Expected values of copy and original to be equal"
-    testCase "" <| fun _ -> 
+    testCase "char" <| fun _ -> 
         let original, copy = constructDeepCopiedObj 'A'
         Expect.equal copy original "Expected values of copy and original to be equal"
-    testCase "" <| fun _ -> 
+    testCase "string" <| fun _ -> 
         let original, copy = constructDeepCopiedObj "Hi"
         Expect.equal copy original "Expected values of copy and original to be equal"
-    testCase "" <| fun _ -> 
+    testCase "unit" <| fun _ -> 
         let original, copy = constructDeepCopiedObj ()
         Expect.equal copy original "Expected values of copy and original to be equal"
 ]

--- a/tests/DynamicObject.Tests/CopyUtils.tryDeepCopyObj/ResizeArrays.fs
+++ b/tests/DynamicObject.Tests/CopyUtils.tryDeepCopyObj/ResizeArrays.fs
@@ -1,0 +1,2 @@
+﻿module DeepCopyResizeArrays
+

--- a/tests/DynamicObject.Tests/CopyUtils.tryDeepCopyObj/ResizeArrays.fs
+++ b/tests/DynamicObject.Tests/CopyUtils.tryDeepCopyObj/ResizeArrays.fs
@@ -10,7 +10,7 @@ let tests_DeepCopyResizeArrays = testList "ResizeArrays" [
     testCase "bool" <| fun _ -> 
         let arr = ResizeArray([true; false])
         let original, copy = constructDeepCopiedObj arr
-        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
         Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
         arr[0] <- false
         Expect.sequenceEqual original (ResizeArray([false; false])) "Original schould have been mutated"
@@ -18,7 +18,7 @@ let tests_DeepCopyResizeArrays = testList "ResizeArrays" [
     testCase "byte" <| fun _ -> 
         let arr = ResizeArray([1uy; 2uy])
         let original, copy = constructDeepCopiedObj arr
-        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
         Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
         arr[0] <- 2uy
         Expect.sequenceEqual original (ResizeArray([2uy; 2uy])) "Original schould have been mutated"
@@ -26,7 +26,7 @@ let tests_DeepCopyResizeArrays = testList "ResizeArrays" [
     testCase "sbyte" <| fun _ -> 
         let arr = ResizeArray([1y; 2y])
         let original, copy = constructDeepCopiedObj arr
-        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
         Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
         arr[0] <- 2y
         Expect.sequenceEqual original (ResizeArray([2y; 2y])) "Original schould have been mutated"
@@ -34,7 +34,7 @@ let tests_DeepCopyResizeArrays = testList "ResizeArrays" [
     testCase "int16" <| fun _ -> 
         let arr = ResizeArray([1s; 2s])
         let original, copy = constructDeepCopiedObj arr
-        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
         Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
         arr[0] <- 2s
         Expect.sequenceEqual original (ResizeArray([2s; 2s])) "Original schould have been mutated"
@@ -42,7 +42,7 @@ let tests_DeepCopyResizeArrays = testList "ResizeArrays" [
     testCase "uint16" <| fun _ ->
         let arr = ResizeArray([1us; 2us])
         let original, copy = constructDeepCopiedObj arr
-        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
         Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
         arr[0] <- 2us
         Expect.sequenceEqual original (ResizeArray([2us; 2us])) "Original schould have been mutated"
@@ -50,7 +50,7 @@ let tests_DeepCopyResizeArrays = testList "ResizeArrays" [
     testCase "int" <| fun _ -> 
         let arr = ResizeArray([1; 2])
         let original, copy = constructDeepCopiedObj arr
-        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
         Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
         arr[0] <- 2
         Expect.sequenceEqual original (ResizeArray([2; 2])) "Original schould have been mutated"
@@ -58,7 +58,7 @@ let tests_DeepCopyResizeArrays = testList "ResizeArrays" [
     testCase "uint" <| fun _ -> 
         let arr = ResizeArray([1u; 2u])
         let original, copy = constructDeepCopiedObj arr
-        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
         Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
         arr[0] <- 2u
         Expect.sequenceEqual original (ResizeArray([2u; 2u])) "Original schould have been mutated"
@@ -66,7 +66,7 @@ let tests_DeepCopyResizeArrays = testList "ResizeArrays" [
     testCase "int64" <| fun _ -> 
         let arr = ResizeArray([1L; 2L])
         let original, copy = constructDeepCopiedObj arr
-        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
         Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
         arr[0] <- 2L
         Expect.sequenceEqual original (ResizeArray([2L; 2L])) "Original schould have been mutated"
@@ -74,7 +74,7 @@ let tests_DeepCopyResizeArrays = testList "ResizeArrays" [
     testCase "uint64" <| fun _ -> 
         let arr = ResizeArray([1uL; 2uL])
         let original, copy = constructDeepCopiedObj arr
-        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
         Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
         arr[0] <- 2uL
         Expect.sequenceEqual original (ResizeArray([2uL; 2uL])) "Original schould have been mutated"
@@ -82,7 +82,7 @@ let tests_DeepCopyResizeArrays = testList "ResizeArrays" [
     testCase "float" <| fun _ -> 
         let arr = ResizeArray([1.0; 2.0])
         let original, copy = constructDeepCopiedObj arr
-        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
         Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
         arr[0] <- 2.0
         Expect.sequenceEqual original (ResizeArray([2.0; 2.0])) "Original schould have been mutated"
@@ -90,7 +90,7 @@ let tests_DeepCopyResizeArrays = testList "ResizeArrays" [
     testCase "float32" <| fun _ -> 
         let arr = ResizeArray([1.0f; 2.0f])
         let original, copy = constructDeepCopiedObj arr
-        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
         Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
         arr[0] <- 2.0f
         Expect.sequenceEqual original (ResizeArray([2.0f; 2.0f])) "Original schould have been mutated"
@@ -98,7 +98,7 @@ let tests_DeepCopyResizeArrays = testList "ResizeArrays" [
     testCase "char" <| fun _ -> 
         let arr = ResizeArray(['A'; 'B'])
         let original, copy = constructDeepCopiedObj arr
-        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
         Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
         arr[0] <- 'B'
         Expect.sequenceEqual original (ResizeArray(['B'; 'B'])) "Original schould have been mutated"
@@ -106,7 +106,7 @@ let tests_DeepCopyResizeArrays = testList "ResizeArrays" [
     testCase "string" <| fun _ -> 
         let arr = ResizeArray(["Hi"; "Bye"])
         let original, copy = constructDeepCopiedObj arr
-        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
         Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
         arr[0] <- "Bye"
         Expect.sequenceEqual original (ResizeArray(["Bye"; "Bye"])) "Original schould have been mutated"
@@ -114,9 +114,11 @@ let tests_DeepCopyResizeArrays = testList "ResizeArrays" [
     testCase "unit" <| fun _ -> 
         let arr = ResizeArray([(); ()])
         let original, copy = constructDeepCopiedObj arr
-        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
         Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
-        arr.Add(())
+        // transpilation fun
+        let arr2 = ResizeArray([()])
+        arr.Add(arr2[0])
         Expect.sequenceEqual original (ResizeArray([(); (); ()])) "Original schould have been mutated"
         Expect.sequenceEqual copy (ResizeArray([(); ()])) "Clone should not be affected by original mutation"
         
@@ -126,7 +128,7 @@ let tests_DeepCopyResizeArrays = testList "ResizeArrays" [
     testCase "decimal" <| fun _ -> 
         let arr = ResizeArray([1.0M; 2.0M])
         let original, copy = constructDeepCopiedObj arr
-        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
         Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
         arr[0] <- 2.0M
         Expect.sequenceEqual original (ResizeArray([2.0M; 2.0M])) "Original schould have been mutated"
@@ -136,11 +138,11 @@ let tests_DeepCopyResizeArrays = testList "ResizeArrays" [
     #if !FABLE_COMPILER
     testCase "nativeint" <| fun _ -> 
         let original, copy = constructDeepCopiedObj (ResizeArray([System.IntPtr(1); System.IntPtr(2)]))
-        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
         Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
     testCase "unativeint" <| fun _ -> 
         let original, copy = constructDeepCopiedObj (ResizeArray([System.UIntPtr(1u); System.UIntPtr(2u)]))
-        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.sequenceEqual copy original "Expected values of copy and original to be equal"
         Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
     #endif
 ]

--- a/tests/DynamicObject.Tests/CopyUtils.tryDeepCopyObj/ResizeArrays.fs
+++ b/tests/DynamicObject.Tests/CopyUtils.tryDeepCopyObj/ResizeArrays.fs
@@ -1,2 +1,146 @@
 ﻿module DeepCopyResizeArrays
 
+open System
+open Fable.Pyxpecto
+open DynamicObj
+open Fable.Core
+open TestUtils
+
+let tests_DeepCopyResizeArrays = testList "ResizeArrays" [
+    testCase "bool" <| fun _ -> 
+        let arr = ResizeArray([true; false])
+        let original, copy = constructDeepCopiedObj arr
+        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+        arr[0] <- false
+        Expect.sequenceEqual original (ResizeArray([false; false])) "Original schould have been mutated"
+        Expect.sequenceEqual copy (ResizeArray([true; false])) "Clone should not be affected by original mutation"
+    testCase "byte" <| fun _ -> 
+        let arr = ResizeArray([1uy; 2uy])
+        let original, copy = constructDeepCopiedObj arr
+        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+        arr[0] <- 2uy
+        Expect.sequenceEqual original (ResizeArray([2uy; 2uy])) "Original schould have been mutated"
+        Expect.sequenceEqual copy (ResizeArray([1uy; 2uy])) "Clone should not be affected by original mutation"
+    testCase "sbyte" <| fun _ -> 
+        let arr = ResizeArray([1y; 2y])
+        let original, copy = constructDeepCopiedObj arr
+        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+        arr[0] <- 2y
+        Expect.sequenceEqual original (ResizeArray([2y; 2y])) "Original schould have been mutated"
+        Expect.sequenceEqual copy (ResizeArray([1y; 2y])) "Clone should not be affected by original mutation"
+    testCase "int16" <| fun _ -> 
+        let arr = ResizeArray([1s; 2s])
+        let original, copy = constructDeepCopiedObj arr
+        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+        arr[0] <- 2s
+        Expect.sequenceEqual original (ResizeArray([2s; 2s])) "Original schould have been mutated"
+        Expect.sequenceEqual copy (ResizeArray([1s; 2s])) "Clone should not be affected by original mutation"
+    testCase "uint16" <| fun _ ->
+        let arr = ResizeArray([1us; 2us])
+        let original, copy = constructDeepCopiedObj arr
+        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+        arr[0] <- 2us
+        Expect.sequenceEqual original (ResizeArray([2us; 2us])) "Original schould have been mutated"
+        Expect.sequenceEqual copy (ResizeArray([1us; 2us])) "Clone should not be affected by original mutation"
+    testCase "int" <| fun _ -> 
+        let arr = ResizeArray([1; 2])
+        let original, copy = constructDeepCopiedObj arr
+        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+        arr[0] <- 2
+        Expect.sequenceEqual original (ResizeArray([2; 2])) "Original schould have been mutated"
+        Expect.sequenceEqual copy (ResizeArray([1; 2])) "Clone should not be affected by original mutation"
+    testCase "uint" <| fun _ -> 
+        let arr = ResizeArray([1u; 2u])
+        let original, copy = constructDeepCopiedObj arr
+        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+        arr[0] <- 2u
+        Expect.sequenceEqual original (ResizeArray([2u; 2u])) "Original schould have been mutated"
+        Expect.sequenceEqual copy (ResizeArray([1u; 2u])) "Clone should not be affected by original mutation"
+    testCase "int64" <| fun _ -> 
+        let arr = ResizeArray([1L; 2L])
+        let original, copy = constructDeepCopiedObj arr
+        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+        arr[0] <- 2L
+        Expect.sequenceEqual original (ResizeArray([2L; 2L])) "Original schould have been mutated"
+        Expect.sequenceEqual copy (ResizeArray([1L; 2L])) "Clone should not be affected by original mutation"
+    testCase "uint64" <| fun _ -> 
+        let arr = ResizeArray([1uL; 2uL])
+        let original, copy = constructDeepCopiedObj arr
+        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+        arr[0] <- 2uL
+        Expect.sequenceEqual original (ResizeArray([2uL; 2uL])) "Original schould have been mutated"
+        Expect.sequenceEqual copy (ResizeArray([1uL; 2uL])) "Clone should not be affected by original mutation"
+    testCase "float" <| fun _ -> 
+        let arr = ResizeArray([1.0; 2.0])
+        let original, copy = constructDeepCopiedObj arr
+        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+        arr[0] <- 2.0
+        Expect.sequenceEqual original (ResizeArray([2.0; 2.0])) "Original schould have been mutated"
+        Expect.sequenceEqual copy (ResizeArray([1.0; 2.0])) "Clone should not be affected by original mutation"
+    testCase "float32" <| fun _ -> 
+        let arr = ResizeArray([1.0f; 2.0f])
+        let original, copy = constructDeepCopiedObj arr
+        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+        arr[0] <- 2.0f
+        Expect.sequenceEqual original (ResizeArray([2.0f; 2.0f])) "Original schould have been mutated"
+        Expect.sequenceEqual copy (ResizeArray([1.0f; 2.0f])) "Clone should not be affected by original mutation"
+    testCase "char" <| fun _ -> 
+        let arr = ResizeArray(['A'; 'B'])
+        let original, copy = constructDeepCopiedObj arr
+        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+        arr[0] <- 'B'
+        Expect.sequenceEqual original (ResizeArray(['B'; 'B'])) "Original schould have been mutated"
+        Expect.sequenceEqual copy (ResizeArray(['A'; 'B'])) "Clone should not be affected by original mutation"
+    testCase "string" <| fun _ -> 
+        let arr = ResizeArray(["Hi"; "Bye"])
+        let original, copy = constructDeepCopiedObj arr
+        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+        arr[0] <- "Bye"
+        Expect.sequenceEqual original (ResizeArray(["Bye"; "Bye"])) "Original schould have been mutated"
+        Expect.sequenceEqual copy (ResizeArray(["Hi"; "Bye"])) "Clone should not be affected by original mutation"
+    testCase "unit" <| fun _ -> 
+        let arr = ResizeArray([(); ()])
+        let original, copy = constructDeepCopiedObj arr
+        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+        arr.Add(())
+        Expect.sequenceEqual original (ResizeArray([(); (); ()])) "Original schould have been mutated"
+        Expect.sequenceEqual copy (ResizeArray([(); ()])) "Clone should not be affected by original mutation"
+        
+    // some cases are not transpilable
+
+    #if !FABLE_COMPILER_PYTHON
+    testCase "decimal" <| fun _ -> 
+        let arr = ResizeArray([1.0M; 2.0M])
+        let original, copy = constructDeepCopiedObj arr
+        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+        arr[0] <- 2.0M
+        Expect.sequenceEqual original (ResizeArray([2.0M; 2.0M])) "Original schould have been mutated"
+        Expect.sequenceEqual copy (ResizeArray([1.0M; 2.0M])) "Clone should not be affected by original mutation"
+    #endif
+
+    #if !FABLE_COMPILER
+    testCase "nativeint" <| fun _ -> 
+        let original, copy = constructDeepCopiedObj (ResizeArray([System.IntPtr(1); System.IntPtr(2)]))
+        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+    testCase "unativeint" <| fun _ -> 
+        let original, copy = constructDeepCopiedObj (ResizeArray([System.UIntPtr(1u); System.UIntPtr(2u)]))
+        Expect.equal copy original "Expected values of copy and original to be equal"
+        Expect.notReferenceEqual copy original "Expected values of copy and original to be not reference equal"
+    #endif
+]

--- a/tests/DynamicObject.Tests/DynamicObject.Tests.fsproj
+++ b/tests/DynamicObject.Tests/DynamicObject.Tests.fsproj
@@ -9,6 +9,13 @@
 
   <ItemGroup>
     <Compile Include="TestUtils.fs" />
+    <Compile Include="CopyUtils.tryDeepCopyObj\Primitives.fs" />
+    <Compile Include="CopyUtils.tryDeepCopyObj\ResizeArrays.fs" />
+    <Compile Include="CopyUtils.tryDeepCopyObj\Dictionaries.fs" />
+    <Compile Include="CopyUtils.tryDeepCopyObj\DynamicObjCollections.fs" />
+    <Compile Include="CopyUtils.tryDeepCopyObj\ICloneable.fs" />
+    <Compile Include="CopyUtils.tryDeepCopyObj\DynamicObj.fs" />
+    <Compile Include="CopyUtils.tryDeepCopyObj\Main.fs" />
     <Compile Include="DynamicObj\RemoveProperty.fs" />
     <Compile Include="DynamicObj\SetProperty.fs" />
     <Compile Include="DynamicObj\GetHashcode.fs" />

--- a/tests/DynamicObject.Tests/Main.fs
+++ b/tests/DynamicObject.Tests/Main.fs
@@ -4,6 +4,7 @@ open Fable.Pyxpecto
 
 let all = testSequenced <| testList "DynamicObj" [
     ReflectionUtils.Tests.main
+    CopyUtils.Tests.main
     DynamicObj.Tests.main
     DynObj.Tests.main
     Inheritance.Tests.main

--- a/tests/DynamicObject.Tests/TestUtils.fs
+++ b/tests/DynamicObject.Tests/TestUtils.fs
@@ -36,6 +36,9 @@ let constructDeepCopiedClone<'T> (props: seq<string*obj>) =
     let clone = original.DeepCopyProperties()
     original, clone |> unbox<'T>
 
+let constructDeepCopiedObj<'T> (original: 'T) =
+    original, (CopyUtils.tryDeepCopyObj original |> unbox<'T>)
+
 let bulkMutate (props: seq<string*obj>) (dyn: #DynamicObj) =
     props |> Seq.iter (fun (propertyName, propertyValue) -> dyn.SetProperty(propertyName, propertyValue))
 
@@ -73,4 +76,8 @@ module Expect =
 
     let referenceEqual actual expected message =
         if not (LanguagePrimitives.PhysicalEquality actual expected) then
+            failwith message
+
+    let notReferenceEqual actual expected message =
+        if (LanguagePrimitives.PhysicalEquality actual expected) then
             failwith message

--- a/tests/DynamicObject.Tests/TestUtils.fs
+++ b/tests/DynamicObject.Tests/TestUtils.fs
@@ -33,8 +33,8 @@ let constructDeepCopiedClone<'T> (props: seq<string*obj>) =
     let original = DynamicObj()
     props
     |> Seq.iter (fun (propertyName, propertyValue) -> original.SetProperty(propertyName, propertyValue))
-    let clone = original.DeepCopyProperties()
-    original, clone |> unbox<'T>
+    let clone : 'T = original.DeepCopyProperties() |> unbox<'T>
+    original, clone 
 
 let constructDeepCopiedObj<'T> (original: 'T) =
     original, (CopyUtils.tryDeepCopyObj original |> unbox<'T>)

--- a/tests/DynamicObject.Tests/TestUtils.fs
+++ b/tests/DynamicObject.Tests/TestUtils.fs
@@ -59,6 +59,13 @@ module DynObj =
             | _ -> failwith "Empty property list"
         getProp dyn props
 
+#if FABLE_COMPILER_PYTHON
+module Py =
+    [<Emit("$0 is $1")>]
+    let isReferenceEqual o1 o2 : bool =
+        nativeOnly
+#endif
+
 module Expect =
     /// Expects the `actual` sequence to equal the `expected` one.
     let sequenceEqual actual expected message =
@@ -74,10 +81,22 @@ module Expect =
         failwithf "%s. Sequence actual longer than expected, at pos %i found item %O."
           message i a
 
+
+
     let referenceEqual actual expected message =
+        #if FABLE_COMPILER_PYTHON
+        if not (Py.isReferenceEqual actual expected) then
+            failwith message
+        #else
         if not (LanguagePrimitives.PhysicalEquality actual expected) then
             failwith message
+        #endif
 
     let notReferenceEqual actual expected message =
+        #if FABLE_COMPILER_PYTHON
+        if (Py.isReferenceEqual actual expected) then
+            failwith message
+        #else
         if (LanguagePrimitives.PhysicalEquality actual expected) then
             failwith message
+        #endif


### PR DESCRIPTION
This PR will

- introduce more type safe deep copy capabilities for .NET:
  - ResizeArrays and Dictionaries containing any combination of basic F# types
  - Dictionaries containing DynamicObj as keys or values in any combination with DynamicObj or basic F# types as keys or values
- Keep js/py results consistent