### PR TITLE
Hotfix DynamicObj hash failing for empty list

### DIFF
--- a/src/DynamicObj/DynamicObj.fs
+++ b/src/DynamicObj/DynamicObj.fs
@@ -420,7 +420,7 @@ and HashUtils =
                     let c = en.Current :?> System.Collections.DictionaryEntry
                     HashCodes.mergeHashes (hash c.Key) (HashUtils.deepHash c.Value)
             ]
-            |> List.reduce HashCodes.mergeHashes
+            |> fun l -> if l.IsEmpty then 0 else l |> List.reduce HashCodes.mergeHashes
         #endif
         | :? System.Collections.IEnumerable as e ->
             let en = e.GetEnumerator()
@@ -428,7 +428,7 @@ and HashUtils =
                 while en.MoveNext() do 
                     HashUtils.deepHash en.Current
             ]
-            |> List.reduce HashCodes.mergeHashes
+            |> fun l -> if l.IsEmpty then 0 else l |> List.reduce HashCodes.mergeHashes
         | _ -> DynamicObj.HashCodes.hash o
 
 and CopyUtils =

--- a/tests/DynamicObject.Tests/HashUtils.fs
+++ b/tests/DynamicObject.Tests/HashUtils.fs
@@ -146,6 +146,8 @@ let tests_Dictionary =
 
 let tests_Lists = 
     testList "Lists" [
+        testCase "Empty" <| fun _ ->               
+            Expect.equal (HashUtils.deepHash []) (HashUtils.deepHash []) "Empty List should return consistent Hash"       
         testList "Shuffled Int" [
             testCase "1v1" <| fun _ ->               
                 Expect.equal (HashUtils.deepHash intList1) (HashUtils.deepHash intList1) "Same List should return consistent Hash"
@@ -167,6 +169,8 @@ let tests_Lists =
 
 let tests_Array = 
     testList "Array" [
+        testCase "Empty" <| fun _ ->               
+            Expect.equal (HashUtils.deepHash [||]) (HashUtils.deepHash [||]) "Empty Array should return consistent Hash"
         testList "Shuffled Int" [
             testCase "1v1" <| fun _ ->               
                 Expect.equal (HashUtils.deepHash intArray1) (HashUtils.deepHash intArray1) "Same Array should return consistent Hash"
@@ -179,6 +183,8 @@ let tests_Array =
 
 let tests_Seq = 
     testList "Seq" [
+        testCase "Empty" <| fun _ ->               
+            Expect.equal (HashUtils.deepHash Seq.empty) (HashUtils.deepHash Seq.empty) "Empty Seq should return consistent Hash"
         testList "Shuffled Int" [
             testCase "1v1" <| fun _ ->               
                 Expect.equal (HashUtils.deepHash intSeq1) (HashUtils.deepHash intSeq1) "Same Seq should return consistent Hash"
@@ -191,6 +197,8 @@ let tests_Seq =
 
 let tests_ResizeArray = 
     testList "ResizeArray" [
+        testCase "Empty" <| fun _ ->               
+            Expect.equal (HashUtils.deepHash (ResizeArray [])) (HashUtils.deepHash (ResizeArray [])) "Empty ResizeArray should return consistent Hash"
         testList "Shuffled Int" [
             testCase "1v1" <| fun _ ->
                 


### PR DESCRIPTION
fixes #53 